### PR TITLE
Remove stale path references and update datasets docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ TURBOPUFFER_API_KEY=
 
 # OpenRouter API Key (for multi-model access)
 # Get yours at: https://openrouter.ai/keys
-# Used in: patterns/prompt/prompt_session.py, use_cases/ai_visibility_tracking.py
+# Used in: examples/prompt/prompt_session.py
 OPENROUTER_API_KEY=sk-or-v1-
 
 # HuggingFace Token (for private datasets)
@@ -34,13 +34,13 @@ OPENROUTER_API_KEY=sk-or-v1-
 HF_TOKEN=
 
 # AWS Credentials (for S3 data ingestion examples)
-# Used in: use_cases/social_recommendation/
+# Used in: datasets/common_crawl/, datasets/tpch/
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SESSION_TOKEN=
 
 # Databricks Unity Catalog (for UC integration examples)
-# Used in: use_cases/social_recommendation/write_index_to_uc.py
+# Used in: examples/prompt/prompt_unity_catalog.py
 UC_TABLE_NAME=
 
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ End-to-end workflows. These are where things get interesting.
 | [chunking_strategies.py](pipelines/context_engineering/chunking_strategies.py) | Compare fixed-size, sentence, and paragraph chunking |
 | [few_shot_example_selection.py](pipelines/context_engineering/few_shot_example_selection.py) | Embedding-based few-shot selection |
 | [llm_judge_elo.py](pipelines/context_engineering/llm_judge_elo.py) | LLM-as-judge with ELO ranking |
-| [sliding_window_overlap.py](pipelines/context_engineering/sliding_window_overlap.py) | Sliding window chunking with overlap |
-| [context_kernel.py](pipelines/context_engineering/context_kernel.py) | Context kernel abstraction |
 
 ### Audio & video
 

--- a/datasets/DATASET_SUMMARY.md
+++ b/datasets/DATASET_SUMMARY.md
@@ -2,14 +2,13 @@
 
 ## Overview
 
-Comprehensive examples for 5 public datasets available in Daft's S3 buckets, organized by use case with 25 files total (21 Python examples + 4 documentation files).
+Comprehensive examples for 4 public datasets available in Daft's S3 buckets, organized by use case with 18 files total (15 Python examples + 3 documentation files).
 
-## New Folder Structure
+## Folder Structure
 
 ```
-usage_patterns/datasets/
+datasets/
 ├── README.md                              # Main overview with all datasets
-├── MIGRATION_SUMMARY.md                   # Common Crawl migration guide
 ├── DATASET_SUMMARY.md                     # This file
 │
 ├── common_crawl/                          # daft.datasets.common_crawl()
@@ -19,13 +18,8 @@ usage_patterns/datasets/
 │   ├── basic_wat.py
 │   ├── content_analysis.py
 │   ├── text_deduplication.py
-│   └── chunk_embed.py
-│
-├── reddit_irl/                            # s3://daft-public-datasets/reddit-irl/
-│   ├── README.md
-│   ├── basic_comments.py
-│   ├── basic_images.py
-│   └── embeddings.py
+│   ├── chunk_embed.py
+│   └── common.py
 │
 ├── tpch/                                  # s3://daft-public-datasets/tpch-lineitem/
 │   ├── README.md
@@ -51,13 +45,14 @@ usage_patterns/datasets/
 ### 1. Common Crawl
 **Focus:** `daft.datasets` API for web-scale text data
 
-**Files:** 6 examples + 1 README
+**Files:** 7 examples + 1 README
 - `basic_warc.py` - Full HTTP responses with headers
 - `basic_wet.py` - Plain text extracts (smallest)
 - `basic_wat.py` - Metadata only (medium)
 - `content_analysis.py` - MIME type distribution analysis
 - `text_deduplication.py` - MinHash + LSH paragraph deduplication
 - `chunk_embed.py` - spaCy chunking + sentence-transformers embeddings
+- `common.py` - Shared utilities for Common Crawl examples
 
 **Key Features:**
 - Three content types: WARC/WET/WAT
@@ -65,36 +60,11 @@ usage_patterns/datasets/
 - Requires AWS credentials (requester-pays bucket)
 - Ideal for LLM training and web mining
 
-**Authentication:** ✅ Required (AWS credentials)
+**Authentication:** Required (AWS credentials)
 
 ---
 
-### 2. Reddit IRL
-**Focus:** Social media analytics with text + images
-
-**Files:** 3 examples + 1 README
-- `basic_comments.py` - Load and analyze 10M+ comments
-- `basic_images.py` - Reddit posts with images
-- `embeddings.py` - Pre-computed Qwen3 embeddings
-
-**Key Features:**
-- 10M+ Reddit comments
-- Thousands of images from Reddit posts
-- Pre-computed embeddings for semantic search
-- Multiple subreddits included
-- Partitioned data structure
-
-**Authentication:** ❌ Public (no credentials needed)
-
-**Use Cases:**
-- Sentiment analysis
-- Trend detection
-- Social recommendation systems
-- Content moderation
-
----
-
-### 3. TPC-H Lineitem
+### 2. TPC-H Lineitem
 **Focus:** SQL benchmark and performance testing
 
 **Files:** 3 examples + 1 README
@@ -108,7 +78,7 @@ usage_patterns/datasets/
 - Industry-standard benchmark
 - Tests parallel CSV reading, aggregations, joins
 
-**Authentication:** ❌ Public (no credentials needed)
+**Authentication:** Public (no credentials needed)
 
 **Use Cases:**
 - SQL query performance testing
@@ -118,7 +88,7 @@ usage_patterns/datasets/
 
 ---
 
-### 4. Open Images
+### 3. Open Images
 **Focus:** Computer vision with validation images
 
 **Files:** 3 examples + 1 README
@@ -132,7 +102,7 @@ usage_patterns/datasets/
 - JPEG format
 - Diverse real-world content
 
-**Authentication:** ❌ Public (no credentials needed)
+**Authentication:** Public (no credentials needed)
 
 **Use Cases:**
 - Image classification
@@ -142,7 +112,7 @@ usage_patterns/datasets/
 
 ---
 
-### 5. LAION Samples
+### 4. LAION Samples
 **Focus:** Image-text pairs for multimodal AI
 
 **Files:** 3 examples + 1 README
@@ -156,7 +126,7 @@ usage_patterns/datasets/
 - CLIP similarity scores (quality metric)
 - Image dimensions and metadata
 
-**Authentication:** ❌ Public (no credentials needed)
+**Authentication:** Public (no credentials needed)
 
 **Use Cases:**
 - CLIP/vision-language training
@@ -171,12 +141,12 @@ usage_patterns/datasets/
 All examples follow consistent patterns:
 
 ### 1. Print Statement Policy
-✅ **Kept:** Structural section headers
+**Kept:** Structural section headers
 ```python
 print("\n=== Sample Results ===")
 ```
 
-❌ **Removed:** Status messages, warnings, success confirmations
+**Removed:** Status messages, warnings, success confirmations
 
 ### 2. Script Metadata (PEP 723)
 All examples include uv-compatible metadata:
@@ -189,7 +159,7 @@ All examples include uv-compatible metadata:
 
 ### 3. Authentication Patterns
 ```python
-# Public datasets (Reddit, TPC-H, Open Images, LAION)
+# Public datasets (TPC-H, Open Images, LAION)
 df = daft.read_parquet("s3://daft-public-datasets/...")
 
 # Common Crawl (requires credentials)
@@ -210,23 +180,17 @@ df = daft.datasets.common_crawl(..., io_config=io_config)
 
 **5-Minute Demos:**
 ```bash
-# Reddit sentiment analysis
-uv run usage_patterns/datasets/reddit_irl/basic_comments.py
-
 # Open Images vision
-uv run usage_patterns/datasets/open_images/vision_models.py
+uv run datasets/open_images/vision_models.py
 
 # TPC-H SQL
-uv run usage_patterns/datasets/tpch/basic_query.py
+uv run datasets/tpch/basic_query.py
 ```
 
 **15-Minute Demos:**
 ```bash
 # LAION semantic search
-uv run usage_patterns/datasets/laion/image_text_pairs.py
-
-# Reddit multimodal
-uv run usage_patterns/datasets/reddit_irl/basic_images.py
+uv run datasets/laion/image_text_pairs.py
 ```
 
 ### For Production (With AWS)
@@ -235,7 +199,7 @@ uv run usage_patterns/datasets/reddit_irl/basic_images.py
 ```bash
 export AWS_ACCESS_KEY_ID="your-key"
 export AWS_SECRET_ACCESS_KEY="your-secret"
-uv run usage_patterns/datasets/common_crawl/basic_wet.py
+uv run datasets/common_crawl/basic_wet.py
 ```
 
 ## Authentication Matrix
@@ -243,7 +207,6 @@ uv run usage_patterns/datasets/common_crawl/basic_wet.py
 | Dataset | Bucket | Credentials | Cost |
 |---------|--------|-------------|------|
 | **Common Crawl** | Common Crawl S3 | AWS keys required | Data transfer (requester-pays) |
-| **Reddit IRL** | daft-public-datasets | Public read | Free |
 | **TPC-H** | daft-public-datasets | Public read | Free |
 | **Open Images** | daft-public-data | Public read | Free |
 | **LAION** | daft-public-data | Public read | Free |
@@ -253,12 +216,10 @@ uv run usage_patterns/datasets/common_crawl/basic_wet.py
 | Use Case | Dataset | Example File | Runtime |
 |----------|---------|--------------|---------|
 | **LLM Training** | Common Crawl WET | `basic_wet.py` | Varies |
-| **Sentiment Analysis** | Reddit IRL | `basic_comments.py` | ~30s |
 | **SQL Benchmarks** | TPC-H | `performance_test.py` | ~2min |
 | **Image Classification** | Open Images | `vision_models.py` | ~1min |
 | **CLIP Training** | LAION | `clip_training.py` | ~1min |
 | **Text Mining** | Common Crawl | `content_analysis.py` | Varies |
-| **Social Analytics** | Reddit IRL | All examples | ~30s |
 | **Vision Models** | Open Images | `vision_models.py` | ~1min |
 | **Multimodal Search** | LAION | `image_text_pairs.py` | ~1min |
 | **Deduplication** | Common Crawl | `text_deduplication.py` | ~5min |
@@ -270,7 +231,6 @@ uv run usage_patterns/datasets/common_crawl/basic_wet.py
 | Dataset | Files | Rows/Images | Total Size | Load Time* |
 |---------|-------|-------------|------------|------------|
 | Common Crawl | Varies | 250B+ pages | Petabytes | Depends on filters |
-| Reddit IRL | ~100s | 10M+ rows | ~50GB | ~2min full scan |
 | TPC-H | 10,000 | 60M rows | 10GB | ~1min full scan |
 | Open Images | 41,620 | 41K images | ~15GB | ~5min to load all |
 | LAION | Sample | Varies | ~1GB metadata | ~10s |
@@ -281,7 +241,6 @@ uv run usage_patterns/datasets/common_crawl/basic_wet.py
 
 For development/testing:
 - **Common Crawl:** `num_files=1` (varies by content type)
-- **Reddit IRL:** `.limit(1000)` for comments
 - **TPC-H:** Use full dataset (optimized for parallel processing)
 - **Open Images:** `.limit(100)` for images
 - **LAION:** `.limit(100)` for metadata
@@ -290,9 +249,9 @@ For development/testing:
 
 ### LangChain Integration
 ```python
-# Reddit IRL for RAG
-df = daft.read_parquet("s3://daft-public-datasets/reddit-irl/comments.parquet")
-# → Chunk → Embed → Vector store → LangChain retriever
+# TPC-H for structured queries
+df = daft.read_csv("s3://daft-public-datasets/tpch-lineitem/**/*.csv")
+# -> Process -> Use in LangChain pipeline
 ```
 
 ### Databricks Integration
@@ -306,7 +265,7 @@ df.write_deltalake("dbfs:/mnt/tpch/lineitem")
 ```python
 # LAION for dataset hub
 df = daft.read_parquet("s3://daft-public-data/tutorials/laion-parquet/*.parquet")
-# → Process → Push to HuggingFace datasets
+# -> Process -> Push to HuggingFace datasets
 ```
 
 ## Documentation Quality
@@ -341,25 +300,24 @@ Each dataset folder includes:
 - All other examples work without credentials
 
 **Recommended Testing Order:**
-1. Reddit IRL (fastest, no auth)
-2. TPC-H (moderate speed, no auth)
-3. Open Images (slow, large files)
-4. LAION (fast metadata)
-5. Common Crawl (slowest, needs AWS)
+1. TPC-H (moderate speed, no auth)
+2. Open Images (slow, large files)
+3. LAION (fast metadata)
+4. Common Crawl (slowest, needs AWS)
 
 ## Next Steps for Users
 
 ### Beginners
-Start with Reddit IRL or TPC-H - public, fast, straightforward:
+Start with TPC-H - public, fast, straightforward:
 ```bash
-uv run usage_patterns/datasets/reddit_irl/basic_comments.py
+uv run datasets/tpch/basic_query.py
 ```
 
 ### Intermediate
 Explore Open Images with vision models:
 ```bash
 export OPENAI_API_KEY="your-key"
-uv run usage_patterns/datasets/open_images/vision_models.py
+uv run datasets/open_images/vision_models.py
 ```
 
 ### Advanced
@@ -367,15 +325,14 @@ Build LLM training pipeline with Common Crawl:
 ```bash
 export AWS_ACCESS_KEY_ID="your-key"
 export AWS_SECRET_ACCESS_KEY="your-secret"
-uv run usage_patterns/datasets/common_crawl/text_deduplication.py
+uv run datasets/common_crawl/text_deduplication.py
 ```
 
 ## Related Documentation
 
-- **Main README:** `usage_patterns/datasets/README.md`
-- **Migration Guide:** `usage_patterns/datasets/MIGRATION_SUMMARY.md`
+- **Main README:** `datasets/README.md`
 - **Daft Docs:** [docs.daft.ai](https://docs.daft.ai)
-- **Use Cases:** `/use_cases/` folder for production examples
+- **Pipelines:** `pipelines/` folder for production examples
 
 ## Contribution Guidelines
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -31,27 +31,7 @@ df.show(5)
 
 ---
 
-### 2. Reddit IRL
-
-**Source:** `s3://daft-public-datasets/reddit-irl/`
-**Size:** 10M+ comments, thousands of images
-**Auth:** Public (no credentials needed)
-
-Reddit comments, posts, images, and pre-computed embeddings for social media analytics.
-
-**Quick Example:**
-```python
-import daft
-
-df = daft.read_parquet("s3://daft-public-datasets/reddit-irl/comments.parquet")
-df.show(5)
-```
-
-**See:** [`reddit_irl/`](./reddit_irl/)
-
----
-
-### 3. TPC-H Lineitem
+### 2. TPC-H Lineitem
 
 **Source:** `s3://daft-public-datasets/tpch-lineitem/`
 **Size:** 10GB (10K files, ~60M rows)
@@ -71,7 +51,7 @@ df.show(5)
 
 ---
 
-### 4. Open Images
+### 3. Open Images
 
 **Source:** `s3://daft-public-data/open-images/`
 **Size:** 41K+ validation images
@@ -93,7 +73,7 @@ df.show(5)
 
 ---
 
-### 5. LAION Samples
+### 4. LAION Samples
 
 **Source:** `s3://daft-public-data/laion-sample-images/`, `s3://daft-public-data/tutorials/laion-parquet/`
 **Size:** Sample of LAION-5B dataset
@@ -116,7 +96,6 @@ df.show(5)
 | Dataset | Size | Type | Use Cases | Auth Required |
 |---------|------|------|-----------|---------------|
 | **Common Crawl** | 250B+ pages | Text, HTML, Metadata | LLM training, web mining | ✅ AWS |
-| **Reddit IRL** | 10M+ comments | Text, Images | Social analytics, NLP | ❌ Public |
 | **TPC-H** | 60M rows, 10GB | Structured CSV | SQL benchmarks | ❌ Public |
 | **Open Images** | 41K images | Images | Computer vision | ❌ Public |
 | **LAION** | Sample dataset | Image-text pairs | Multimodal models | ❌ Public |
@@ -125,7 +104,6 @@ df.show(5)
 
 ### Text Analysis / LLM Training
 - **Common Crawl (WET)** - Massive web text corpus
-- **Reddit IRL** - Social media conversations
 
 ### Computer Vision
 - **Open Images** - Pre-labeled images for classification
@@ -136,7 +114,6 @@ df.show(5)
 
 ### Multimodal AI
 - **LAION** - Image + caption pairs for CLIP-style training
-- **Reddit IRL** - Social posts with images
 
 ## Authentication
 
@@ -197,11 +174,6 @@ df = daft.datasets.common_crawl(
 - `text_deduplication.py` - MinHash deduplication
 - `chunk_embed.py` - Chunking + embeddings
 
-### Reddit IRL
-- `basic_comments.py` - Load and analyze comments
-- `basic_images.py` - Posts with images
-- `embeddings.py` - Pre-computed embeddings
-
 ### TPC-H
 - `basic_query.py` - Standard SQL queries
 - `performance_test.py` - Benchmark Daft
@@ -232,11 +204,6 @@ df = daft.datasets.common_crawl(
 - Use `in_aws=True` on EC2/Lambda
 - Choose smallest content type needed (WET < WAT < WARC)
 
-**Reddit IRL:**
-- Filter by subreddit early
-- Use partition columns in filters
-- Sample for ML model development
-
 **TPC-H:**
 - Leverage parallel CSV reading (10K files)
 - Enable projection pushdown
@@ -252,18 +219,15 @@ df = daft.datasets.common_crawl(
 These datasets are ideal for hackathons and demos:
 
 ### 5-Minute Demos
-- **Reddit IRL comments** - Sentiment analysis, trend detection
 - **Open Images** - Image classification with GPT-4 Vision
 - **TPC-H queries** - SQL performance showcase
 
 ### 15-Minute Demos
 - **LAION pairs** - Build semantic image search
-- **Reddit IRL images** - Multimodal content moderation
 - **TPC-H + SQL** - Complex analytics dashboard
 
 ### Production Examples
 - **Common Crawl** - LLM pre-training pipeline
-- **Reddit IRL + embeddings** - Social recommendation system
 - **LAION** - Train custom CLIP models
 
 ## Authentication Summary
@@ -271,7 +235,6 @@ These datasets are ideal for hackathons and demos:
 | Dataset | Bucket | Auth Required | Credentials |
 |---------|--------|---------------|-------------|
 | Common Crawl | Common Crawl S3 | ✅ Yes | AWS access keys |
-| Reddit IRL | daft-public-datasets | ❌ No | Public read |
 | TPC-H | daft-public-datasets | ❌ No | Public read |
 | Open Images | daft-public-data | ❌ No | Public read |
 | LAION | daft-public-data | ❌ No | Public read |

--- a/datasets/common_crawl/text_deduplication.py
+++ b/datasets/common_crawl/text_deduplication.py
@@ -133,7 +133,9 @@ def small_star(edges: DataFrame) -> DataFrame:
     """Small-star contraction."""
     directed = (
         edges.select(
-            when(col("u") < col("v"), _edge_struct(col("v"), col("u"))).otherwise(_edge_struct(col("u"), col("v"))).alias("e")
+            when(col("u") < col("v"), _edge_struct(col("v"), col("u")))
+            .otherwise(_edge_struct(col("u"), col("v")))
+            .alias("e")
         )
         .select(col("e")["*"])
         .where(col("u") != col("v"))

--- a/datasets/tpch/basic_query.py
+++ b/datasets/tpch/basic_query.py
@@ -13,7 +13,10 @@ if __name__ == "__main__":
     daft.set_planning_config(default_io_config=io_config)
 
     # Load TPC-H lineitem data (single parquet file for fast execution)
-    df = daft.read_parquet("s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet", io_config=io_config)
+    df = daft.read_parquet(
+        "s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet",
+        io_config=io_config,
+    )
 
     print("\n=== Schema ===")
     df.show(1)

--- a/datasets/tpch/performance_test.py
+++ b/datasets/tpch/performance_test.py
@@ -16,7 +16,10 @@ if __name__ == "__main__":
 
     io_config = IOConfig(s3=S3Config(anonymous=True, region_name="us-east-1"))
     daft.set_planning_config(default_io_config=io_config)
-    df = daft.read_parquet("s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet", io_config=io_config)
+    df = daft.read_parquet(
+        "s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet",
+        io_config=io_config,
+    )
 
     print("\n=== Performance Benchmark ===")
 

--- a/datasets/tpch/sql_queries.py
+++ b/datasets/tpch/sql_queries.py
@@ -12,7 +12,10 @@ if __name__ == "__main__":
     daft.set_planning_config(default_io_config=io_config)
 
     # Load TPC-H data
-    df = daft.read_parquet("s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet", io_config=io_config)
+    df = daft.read_parquet(
+        "s3://daft-public-datasets/tpch-lineitem/100_0/32/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet",
+        io_config=io_config,
+    )
 
     print("\n=== TPC-H Query 1: Pricing Summary (SQL) ===")
     result = daft.sql("""

--- a/examples/commoncrawl/cc_wet_paragraph_dedupe.py
+++ b/examples/commoncrawl/cc_wet_paragraph_dedupe.py
@@ -142,7 +142,9 @@ def small_star(edges: DataFrame) -> DataFrame:
     """Small-star: orient each edge so u is larger endpoint, then connect all neighbors to min."""
     directed = (
         edges.select(
-            when(col("u") < col("v"), _edge_struct(col("v"), col("u"))).otherwise(_edge_struct(col("u"), col("v"))).alias("e")
+            when(col("u") < col("v"), _edge_struct(col("v"), col("u")))
+            .otherwise(_edge_struct(col("u"), col("v")))
+            .alias("e")
         )
         .select(col("e")["*"])
         .where(col("u") != col("v"))

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -94,14 +94,14 @@ uv run quickstart/05_video_file.py
 
 After completing these quickstart examples, explore:
 
-- **[patterns/](../patterns/)** - Atomic feature demonstrations (prompt, embed, classify, io, etc.)
-- **[use_cases/](../use_cases/)** - Complete end-to-end pipelines
+- **[examples/](../examples/)** - Atomic feature demonstrations (prompt, embed, classify, io, etc.)
+- **[pipelines/](../pipelines/)** - Complete end-to-end pipelines
 - **[notebooks/](../notebooks/)** - Interactive tutorials
 
 ## Requirements
 
 Most examples need:
-- Python 3.10+
+- Python 3.12+
 - `uv` package manager (for dependency isolation)
 
 Some examples require API keys (set in `.env`):


### PR DESCRIPTION
## Summary

- Remove phantom pipeline references (`sliding_window_overlap.py`, `context_kernel.py`) from main README - these files don't exist
- Fix quickstart README stale links (`patterns/` -> `examples/`, `use_cases/` -> `pipelines/`)
- Update Python version requirement from 3.10+ to 3.12+ in quickstart README
- Update `.env.example` to reference correct paths (remove stale `use_cases/` references)
- Rewrite `datasets/DATASET_SUMMARY.md` to reflect current repo structure (removed all `usage_patterns/datasets/` paths)
- Remove non-existent `reddit_irl` dataset references from `datasets/README.md`

## Test plan

- [ ] Verify all README links resolve to existing files
- [ ] Run `uv run` on quickstart examples to confirm documentation accuracy

Slack thread: https://eventualgroup.slack.com/archives/C0ARMCJKZCN/p1776099478925479?thread_ts=1776069120.108329&cid=C0ARMCJKZCN

https://claude.ai/code/session_01UryDc8LumNNuFjb1pgFzwb