### PR TITLE
Add transcribe + speaker diarization pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ daft-examples/
 │   ├── image_understanding_eval/
 │   ├── rag/
 │   ├── social_recommendation/
+│   ├── transcribe_diarize/
 │   └── voice_ai_analytics/
 ├── datasets/            # Dataset-specific processing (Common Crawl, LAION, etc.)
 ├── models/              # Model integration helpers

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,0 +1,169 @@
+# Pipelines
+
+End-to-end multi-stage pipelines that combine multiple Daft features.
+Pipelines that persist intermediate results write to a shared **Iceberg catalog**
+so tables are queryable, versioned, and trivially portable between local dev and
+cloud warehouses.
+
+## Catalog Architecture
+
+```
+pipelines/
+├── catalog.py                  # Shared catalog factory (PyIceberg + Daft)
+├── README.md                   # ← you are here
+│
+├── transcribe_diarize/         # Audio → transcription + speaker diarization
+│   ├── transcribe_diarize.py
+│   ├── diarize_schema.py
+│   └── report_template.html
+│
+├── key_moments_extraction.py   # Transcript → key moments → audio clips
+├── voice_ai_analytics/         # Voice analytics with transcription + QA
+│
+├── context_engineering/        # LLM context patterns (chunking, few-shot, etc.)
+├── image_understanding_eval/   # Vision model evaluation on image datasets
+├── rag/                        # Retrieval-augmented generation
+├── social_recommendation/      # Reddit → image similarity → Unity Catalog
+├── code/                       # Code analysis with GitHub integration
+│
+├── ai_search.py                # PDF → embed → Turbopuffer
+├── data_enrichment.py          # Reddit comments → LLM enrichment
+├── embed_docs.py               # PDF → embeddings → parquet
+├── shot_boundary_detection.py  # Video → frame analysis
+└── ...
+```
+
+### How It Works
+
+Each pipeline that persists data owns a **namespace** in the catalog with its own tables:
+
+```
+transcribe_diarize.transcription   # Faster Whisper output
+transcribe_diarize.diarization     # pyannote speaker segments
+transcribe_diarize.merged          # Combined result with speaker attribution
+```
+
+The catalog is backed by **Apache Iceberg** (via PyIceberg), giving you:
+- Versioned tables with schema evolution
+- Time travel / snapshot queries
+- Seamless migration between local filesystem and cloud object stores
+
+### Configuration
+
+Two environment variables control where data lives:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAFT_WAREHOUSE` | `.data/warehouse` | Root path for table data (local path or `gs://`, `s3://`) |
+| `DAFT_CATALOG_URI` | `sqlite:///<warehouse>/catalog.db` | Catalog metastore connection string |
+
+**Local development** needs no configuration — the defaults create a SQLite-backed
+Iceberg catalog under `.data/warehouse/` (gitignored).
+
+**Cloud deployment** is a URI change:
+
+```bash
+# GCS BigLake
+export DAFT_WAREHOUSE=gs://my-bucket/lakehouse
+export DAFT_CATALOG_URI=sqlite:///path/to/catalog.db
+
+# AWS S3
+export DAFT_WAREHOUSE=s3://my-bucket/lakehouse
+export DAFT_CATALOG_URI=sqlite:///path/to/catalog.db
+
+# Or use a managed metastore (Glue, BigQuery, etc.) by configuring
+# PyIceberg directly in ~/.pyiceberg.yaml
+```
+
+### Using the Catalog in a Pipeline
+
+```python
+import sys
+from pathlib import Path
+
+# Add pipelines/ to path for the shared catalog module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from catalog import ensure_namespace
+
+NAMESPACE = "my_pipeline"
+
+def main():
+    catalog = ensure_namespace(NAMESPACE)
+
+    # Write phase results as tables
+    catalog.write_table(f"{NAMESPACE}.raw", df_raw, mode="overwrite")
+
+    # Read from previous phases
+    df = catalog.read_table(f"{NAMESPACE}.raw")
+
+    # Check if a table exists (for caching)
+    if catalog.has_table(f"{NAMESPACE}.processed"):
+        df = catalog.read_table(f"{NAMESPACE}.processed")
+```
+
+### Querying Tables After a Run
+
+```python
+from catalog import get_catalog
+
+catalog = get_catalog()
+
+# List all tables
+for ns in catalog.list_namespaces():
+    for tbl in catalog.list_tables(ns):
+        print(tbl)
+
+# Read any table
+df = catalog.read_table("transcribe_diarize.merged")
+df.show()
+```
+
+---
+
+## Pipeline Reference
+
+### Pipelines with Catalog Integration
+
+| Pipeline | Namespace | Tables | Description |
+|----------|-----------|--------|-------------|
+| `transcribe_diarize/` | `transcribe_diarize` | `transcription`, `diarization`, `merged` | Audio → transcription + speaker diarization + HTML report |
+
+### Pipelines with External Storage
+
+| Pipeline | Storage | Description |
+|----------|---------|-------------|
+| `ai_search.py` | Turbopuffer | PDF → embed → vector search |
+| `social_recommendation/` | S3 + Delta Lake | Reddit → image similarity → Unity Catalog |
+| `image_understanding_eval/` | S3 | Vision model evaluation |
+| `voice_ai_analytics/` | `.data/` parquet + Lance | Voice analytics with transcription |
+| `key_moments_extraction.py` | `.data/` parquet | Transcript → key moments → audio clips |
+| `data_enrichment.py` | Local parquet | Reddit comments → LLM enrichment |
+| `embed_docs.py` | `.data/` parquet | PDF → embeddings |
+
+### Pipelines without Persistence (show-only)
+
+| Pipeline | Description |
+|----------|-------------|
+| `context_engineering/chunking_strategies.py` | Compare chunking approaches for RAG |
+| `context_engineering/few_shot_example_selection.py` | Dynamic few-shot example selection |
+| `context_engineering/lambda_mapreduce.py` | Map-reduce over documents with LLMs |
+| `context_engineering/llm_judge_elo.py` | LLM-as-judge with Elo ratings |
+| `rag/rag.py` | Simple RAG pipeline |
+| `rag/full_rag.py` | Full RAG with reranking |
+| `shot_boundary_detection.py` | Video shot boundary detection |
+| `code/cursor.py` | Code analysis with GitHub |
+
+---
+
+## Running Pipelines
+
+```bash
+# Most pipelines run with uv (dependencies are declared inline)
+uv run pipelines/transcribe_diarize/transcribe_diarize.py --source audio.m4a
+
+# Check what tables exist after a run
+uv run -c "from pipelines.catalog import get_catalog; [print(t) for t in get_catalog().list_tables('transcribe_diarize')]"
+```
+
+See individual pipeline docstrings for required environment variables and arguments.

--- a/pipelines/catalog.py
+++ b/pipelines/catalog.py
@@ -1,0 +1,70 @@
+# /// script
+# description = "Shared catalog configuration for pipeline table management"
+# requires-python = ">=3.10, <3.13"
+# dependencies = ["daft>=0.7.8", "pyiceberg[sql-sqlite]"]
+# ///
+"""Shared Iceberg catalog for all pipelines.
+
+Every pipeline writes outputs as named tables in a shared catalog, making
+results queryable, cacheable, and portable between local dev and cloud
+warehouses (GCS BigLake, S3, etc.).
+
+Configuration (environment variables):
+  DAFT_WAREHOUSE    — root path for table data   (default: .data/warehouse)
+  DAFT_CATALOG_URI  — catalog metastore URI       (auto-derived from warehouse)
+
+Examples:
+
+  # Local development — no config needed, uses SQLite + filesystem
+  uv run pipelines/transcribe_diarize/transcribe_diarize.py --source audio.m4a
+
+  # GCS BigLake
+  export DAFT_WAREHOUSE=gs://my-bucket/lakehouse
+  export DAFT_CATALOG_URI=sqlite:///path/to/catalog.db
+  uv run pipelines/transcribe_diarize/transcribe_diarize.py --source audio.m4a
+
+Each pipeline owns a namespace (e.g. ``transcribe_diarize``) and writes
+phase outputs as tables within it (``transcribe_diarize.transcription``,
+``transcribe_diarize.diarization``, ``transcribe_diarize.merged``).
+"""
+
+import os
+
+from daft.catalog import Catalog
+
+_catalog: Catalog | None = None
+
+
+def get_catalog() -> Catalog:
+    """Return the shared Daft catalog, creating it on first call.
+
+    Uses PyIceberg's SqlCatalog backed by SQLite for local development.
+    Override via DAFT_WAREHOUSE / DAFT_CATALOG_URI for cloud warehouses.
+    """
+    global _catalog
+    if _catalog is not None:
+        return _catalog
+
+    from pyiceberg.catalog.sql import SqlCatalog
+
+    warehouse = os.environ.get("DAFT_WAREHOUSE", os.path.join(".data", "warehouse"))
+    abs_warehouse = os.path.abspath(warehouse)
+    catalog_uri = os.environ.get(
+        "DAFT_CATALOG_URI",
+        f"sqlite:///{abs_warehouse}/catalog.db",
+    )
+
+    os.makedirs(warehouse, exist_ok=True)
+
+    warehouse_uri = warehouse if "://" in warehouse else f"file://{abs_warehouse}"
+
+    ice_catalog = SqlCatalog("daft_examples", uri=catalog_uri, warehouse=warehouse_uri)
+    _catalog = Catalog.from_iceberg(ice_catalog)
+    return _catalog
+
+
+def ensure_namespace(namespace: str) -> Catalog:
+    """Get the catalog and ensure the given namespace exists."""
+    catalog = get_catalog()
+    catalog.create_namespace_if_not_exists(namespace)
+    return catalog

--- a/pipelines/transcribe_diarize/diarize_schema.py
+++ b/pipelines/transcribe_diarize/diarize_schema.py
@@ -1,0 +1,117 @@
+# /// script
+# description = "Schema definitions for transcription + speaker diarization results"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+"""Daft DataType structs for diarized transcription results.
+
+Extends the base Faster Whisper schema with speaker attribution fields
+on words and segments, plus a SpeakerSegmentStruct for pyannote output.
+"""
+
+from daft import DataType
+
+DiarizedWordStruct = DataType.struct(
+    {
+        "start": DataType.float64(),
+        "end": DataType.float64(),
+        "word": DataType.string(),
+        "probability": DataType.float64(),
+        "speaker": DataType.string(),
+    }
+)
+
+DiarizedSegmentStruct = DataType.struct(
+    {
+        "id": DataType.int64(),
+        "seek": DataType.int64(),
+        "start": DataType.float64(),
+        "end": DataType.float64(),
+        "text": DataType.string(),
+        "tokens": DataType.list(DataType.int64()),
+        "avg_logprob": DataType.float64(),
+        "compression_ratio": DataType.float64(),
+        "no_speech_prob": DataType.float64(),
+        "words": DataType.list(DiarizedWordStruct),
+        "temperature": DataType.float64(),
+        "speaker": DataType.string(),
+    }
+)
+
+SpeakerSegmentStruct = DataType.struct(
+    {
+        "start": DataType.float64(),
+        "end": DataType.float64(),
+        "speaker": DataType.string(),
+    }
+)
+
+TranscriptionOptionsStruct = DataType.struct(
+    {
+        "beam_size": DataType.int64(),
+        "best_of": DataType.int64(),
+        "patience": DataType.float64(),
+        "length_penalty": DataType.float64(),
+        "repetition_penalty": DataType.float64(),
+        "no_repeat_ngram_size": DataType.int64(),
+        "log_prob_threshold": DataType.float64(),
+        "no_speech_threshold": DataType.float64(),
+        "compression_ratio_threshold": DataType.float64(),
+        "condition_on_previous_text": DataType.bool(),
+        "prompt_reset_on_temperature": DataType.float64(),
+        "temperatures": DataType.list(DataType.float64()),
+        "initial_prompt": DataType.python(),
+        "prefix": DataType.string(),
+        "suppress_blank": DataType.bool(),
+        "suppress_tokens": DataType.list(DataType.int64()),
+        "without_timestamps": DataType.bool(),
+        "max_initial_timestamp": DataType.float64(),
+        "word_timestamps": DataType.bool(),
+        "prepend_punctuations": DataType.string(),
+        "append_punctuations": DataType.string(),
+        "multilingual": DataType.bool(),
+        "max_new_tokens": DataType.float64(),
+        "clip_timestamps": DataType.python(),
+        "hallucination_silence_threshold": DataType.float64(),
+        "hotwords": DataType.string(),
+    }
+)
+
+VadOptionsStruct = DataType.struct(
+    {
+        "threshold": DataType.float64(),
+        "neg_threshold": DataType.float64(),
+        "min_speech_duration_ms": DataType.int64(),
+        "max_speech_duration_s": DataType.float64(),
+        "min_silence_duration_ms": DataType.int64(),
+        "speech_pad_ms": DataType.int64(),
+    }
+)
+
+LanguageProbStruct = DataType.struct(
+    {
+        "language": DataType.string(),
+        "probability": DataType.float64(),
+    }
+)
+
+InfoStruct = DataType.struct(
+    {
+        "language": DataType.string(),
+        "language_probability": DataType.float64(),
+        "duration": DataType.float64(),
+        "duration_after_vad": DataType.float64(),
+        "all_language_probs": DataType.list(LanguageProbStruct),
+        "transcription_options": TranscriptionOptionsStruct,
+        "vad_options": VadOptionsStruct,
+    }
+)
+
+DiarizedTranscriptionResult = DataType.struct(
+    {
+        "transcript": DataType.string(),
+        "segments": DataType.list(DiarizedSegmentStruct),
+        "info": InfoStruct,
+        "speaker_segments": DataType.list(SpeakerSegmentStruct),
+    }
+)

--- a/pipelines/transcribe_diarize/report_template.html
+++ b/pipelines/transcribe_diarize/report_template.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Transcript: {{source_name}}</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    max-width: 860px;
+    margin: 2rem auto;
+    padding: 0 1.5rem;
+    color: #111;
+    line-height: 1.6;
+  }
+  h1 { border-bottom: 2px solid #111; padding-bottom: 0.3rem; }
+  h2 { margin-top: 2.5rem; color: #333; }
+  h3 { margin-top: 1.5rem; margin-bottom: 0.3rem; font-size: 1rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ddd; padding: 0.5rem 0.75rem; text-align: left; }
+  th { background: #f5f5f5; }
+  code {
+    background: #f3f4f6;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+    color: #555;
+  }
+  .turn p { margin: 0.3rem 0 0 0; }
+  .meta { color: #666; font-size: 0.9rem; }
+  .swatch {
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    border-radius: 2px;
+    margin-right: 0.4em;
+    vertical-align: middle;
+  }
+  input.rename {
+    border: 1px solid transparent;
+    background: transparent;
+    padding: 0.15rem 0.3rem;
+    font: inherit;
+    font-weight: bold;
+    width: 12rem;
+    border-radius: 3px;
+  }
+  input.rename:hover { border-color: #ddd; background: #fafafa; }
+  input.rename:focus { border-color: #3b82f6; background: #fff; outline: none; }
+  .toolbar { margin: 1rem 0; display: flex; gap: 0.5rem; }
+  .toolbar button {
+    padding: 0.4rem 0.9rem;
+    font: inherit;
+    border: 1px solid #d1d5db;
+    background: #f9fafb;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .toolbar button:hover { background: #f3f4f6; }
+  @media print {
+    .swatch, .toolbar { display: none; }
+    input.rename { border: none; background: none; }
+  }
+</style>
+</head>
+<body>
+
+<h1>Transcript: {{source_name}}</h1>
+
+<p class="meta">
+  <strong>Duration:</strong> {{duration}} &middot;
+  <strong>Language:</strong> {{language}} &middot;
+  <strong>Segments:</strong> {{segments_count}} &middot;
+  <strong>Speakers:</strong> {{speakers_count}}
+</p>
+
+<h2>Speaker Summary</h2>
+<p class="meta">Edit a name to rename that speaker everywhere. Changes save automatically in your browser.</p>
+
+<div class="toolbar">
+  <button type="button" onclick="resetRenames()">Reset to defaults</button>
+  <button type="button" onclick="copyMarkdown()">Copy as Markdown</button>
+</div>
+
+<table>
+  <thead>
+    <tr><th>Speaker</th><th>Speaking Time</th><th>Share</th><th>Words</th></tr>
+  </thead>
+  <tbody>
+{{speaker_table_rows}}
+  </tbody>
+</table>
+
+<h2>Transcript</h2>
+
+<div class="transcript">
+{{turn_blocks}}
+</div>
+
+<script>
+const STORAGE_KEY = {{storage_key_json}};
+const SOURCE_NAME = {{source_name_json}};
+
+function applyRename(speakerId, newName) {
+  document.querySelectorAll(`[data-speaker-id="${speakerId}"]`).forEach(el => {
+    if (el.tagName === "INPUT") {
+      if (el.value !== newName) el.value = newName;
+    } else {
+      el.textContent = newName;
+    }
+  });
+}
+
+function loadRenames() {
+  let renames = {};
+  try { renames = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}"); } catch (_) {}
+  for (const [id, name] of Object.entries(renames)) applyRename(id, name);
+  return renames;
+}
+
+function saveRename(speakerId, newName) {
+  let renames = {};
+  try { renames = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}"); } catch (_) {}
+  if (newName && newName !== speakerId) renames[speakerId] = newName;
+  else delete renames[speakerId];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(renames));
+}
+
+function resetRenames() {
+  localStorage.removeItem(STORAGE_KEY);
+  document.querySelectorAll("input.rename").forEach(inp => {
+    const id = inp.dataset.speakerId;
+    inp.value = id;
+    applyRename(id, id);
+  });
+}
+
+function copyMarkdown() {
+  const lines = [`# Transcript: ${SOURCE_NAME}`, ""];
+  document.querySelectorAll(".turn").forEach(turn => {
+    const speaker = turn.querySelector(".speaker-label").textContent.trim();
+    const ts = turn.querySelector("code").textContent.trim();
+    const text = turn.querySelector("p").textContent.trim();
+    lines.push(`**${speaker}** \`${ts}\``, "", text, "");
+  });
+  const md = lines.join("\n");
+  navigator.clipboard.writeText(md).then(
+    () => alert(`Copied ${md.length} characters as markdown`),
+    err => alert("Copy failed: " + err),
+  );
+}
+
+document.querySelectorAll("input.rename").forEach(inp => {
+  const id = inp.dataset.speakerId;
+  inp.addEventListener("input", e => {
+    const val = e.target.value.trim() || id;
+    applyRename(id, val);
+    saveRename(id, val);
+  });
+});
+
+loadRenames();
+</script>
+
+</body>
+</html>

--- a/pipelines/transcribe_diarize/transcribe_diarize.py
+++ b/pipelines/transcribe_diarize/transcribe_diarize.py
@@ -1,0 +1,438 @@
+# /// script
+# description = "Transcribe + speaker diarization with Faster Whisper and pyannote.audio"
+# requires-python = ">=3.12, <3.13"
+# dependencies = [
+#     "daft>=0.7.8",
+#     "faster-whisper",
+#     "pyannote.audio",
+#     "python-dotenv",
+#     "torch",
+#     "torchaudio",
+# ]
+# ///
+"""
+Transcription + Speaker Diarization Pipeline
+=============================================
+Transcribes audio with faster-whisper, diarizes speakers with pyannote.audio,
+and merges the results so every word and segment is attributed to a speaker.
+
+Architecture:
+  Phase 1 — Transcribe (faster-whisper, CPU)  → transcription.parquet
+  Phase 2 — Diarize   (pyannote 3.1, MPS/GPU) → diarization.parquet
+  Phase 3 — Merge     (timestamp overlap)      → final.parquet
+  Phase 4 — Report    (HTML generation)        → report.html
+
+Phases run sequentially so models don't compete for memory.
+Intermediate parquets are cached — rerun skips completed phases.
+
+Audio is converted to 16 kHz mono WAV before processing (pyannote
+requires exact sample counts that lossy formats like MP3/M4A can't guarantee).
+
+Requirements:
+  - HF_TOKEN env var (pyannote requires Hugging Face authentication)
+  - ffmpeg on PATH (for non-WAV audio conversion)
+
+Usage:
+  uv run transcribe_diarize.py --source /path/to/audio.m4a
+  uv run transcribe_diarize.py --source recording.wav --dest .data/output
+  uv run transcribe_diarize.py --source meeting.m4a --no-cache
+"""
+
+import argparse
+import gc
+import os
+import subprocess
+import time
+from collections import Counter
+from dataclasses import asdict
+
+from dotenv import load_dotenv
+
+DEST_DIR = ".data/transcribe_diarize"
+BATCH_SIZE = 16
+PALETTE = [
+    "#3b82f6",
+    "#10b981",
+    "#f59e0b",
+    "#ef4444",
+    "#8b5cf6",
+    "#ec4899",
+    "#06b6d4",
+    "#84cc16",
+]
+
+
+# ── Audio Preprocessing ─────────────────────────────────────────────────────
+
+
+def ensure_wav(source: str, dest_dir: str) -> str:
+    """Convert audio to 16 kHz mono WAV if not already WAV."""
+    basename = os.path.splitext(os.path.basename(source))[0]
+    wav_path = os.path.join(dest_dir, f"{basename}.wav")
+
+    if os.path.exists(wav_path):
+        print(f"  Using cached WAV: {wav_path}")
+        return wav_path
+
+    if source.lower().endswith(".wav"):
+        return source
+
+    print(f"  Converting to WAV: {source}")
+    t0 = time.perf_counter()
+    subprocess.run(
+        ["ffmpeg", "-i", source, "-ar", "16000", "-ac", "1", "-y", wav_path],
+        capture_output=True,
+        check=True,
+    )
+    print(f"  Converted in {time.perf_counter() - t0:.1f}s")
+    return wav_path
+
+
+# ── Phase 1: Transcription ──────────────────────────────────────────────────
+#
+# Imports are deferred so the Whisper model is only loaded during this phase,
+# freeing memory before diarization starts.
+
+
+def run_transcription(wav_path: str, dest_dir: str, batch_size: int) -> str:
+    """Transcribe audio with faster-whisper. Returns path to parquet."""
+    from diarize_schema import DiarizedSegmentStruct, InfoStruct
+    from faster_whisper import BatchedInferencePipeline, WhisperModel
+
+    import daft
+    from daft import DataType, col
+    from daft.functions import file, unnest
+
+    parquet_path = os.path.join(dest_dir, "transcription.parquet")
+
+    TranscriptionResult = DataType.struct(
+        {
+            "transcript": DataType.string(),
+            "segments": DataType.list(DiarizedSegmentStruct),
+            "info": InfoStruct,
+        }
+    )
+
+    @daft.cls()
+    class Transcriber:
+        def __init__(self):
+            self.model = WhisperModel("distil-large-v3", compute_type="float32", device="cpu")
+            self.pipe = BatchedInferencePipeline(self.model)
+
+        @daft.method(return_dtype=TranscriptionResult)
+        def transcribe(self, audio_file: daft.File):
+            with audio_file.to_tempfile() as tmp:
+                segments_iter, info = self.pipe.transcribe(
+                    str(tmp.name),
+                    vad_filter=True,
+                    vad_parameters=dict(min_silence_duration_ms=500),
+                    word_timestamps=True,
+                    batch_size=batch_size,
+                )
+                segments = [asdict(seg) for seg in segments_iter]
+                for seg in segments:
+                    seg["speaker"] = None
+                    for word in seg.get("words") or []:
+                        word["speaker"] = None
+                return {
+                    "transcript": " ".join(seg["text"] for seg in segments),
+                    "segments": segments,
+                    "info": asdict(info),
+                }
+
+    t0 = time.perf_counter()
+    transcriber = Transcriber()
+
+    df = (
+        daft.from_pydict({"path": [wav_path]})
+        .with_column("audio_file", file(col("path")))
+        .with_column("result", transcriber.transcribe(col("audio_file")))
+        .select("path", unnest(col("result")))
+    )
+    df.write_parquet(parquet_path, write_mode="overwrite")
+    print(f"  Transcription: {time.perf_counter() - t0:.1f}s")
+
+    del transcriber
+    gc.collect()
+
+    return parquet_path
+
+
+# ── Phase 2: Diarization ────────────────────────────────────────────────────
+
+
+def run_diarization(wav_path: str, dest_dir: str, hf_token: str) -> str:
+    """Diarize speakers with pyannote. Returns path to parquet."""
+    import torch
+    from diarize_schema import SpeakerSegmentStruct
+    from pyannote.audio import Pipeline
+
+    import daft
+    from daft import DataType, col
+    from daft.functions import file
+
+    parquet_path = os.path.join(dest_dir, "diarization.parquet")
+
+    device = "mps" if torch.backends.mps.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
+
+    DiarizationResult = DataType.list(SpeakerSegmentStruct)
+
+    @daft.cls()
+    class Diarizer:
+        def __init__(self):
+            self.pipeline = Pipeline.from_pretrained(
+                "pyannote/speaker-diarization-3.1",
+                token=hf_token,
+            )
+            self.pipeline.to(torch.device(device))
+
+        @daft.method(return_dtype=DiarizationResult)
+        def diarize(self, audio_file: daft.File):
+            with audio_file.to_tempfile() as tmp:
+                result = self.pipeline(str(tmp.name))
+                ann = result.speaker_diarization if hasattr(result, "speaker_diarization") else result
+                return [
+                    {"start": turn.start, "end": turn.end, "speaker": speaker}
+                    for turn, _, speaker in ann.itertracks(yield_label=True)
+                ]
+
+    t0 = time.perf_counter()
+    diarizer = Diarizer()
+
+    df = (
+        daft.from_pydict({"path": [wav_path]})
+        .with_column("audio_file", file(col("path")))
+        .with_column("speaker_segments", diarizer.diarize(col("audio_file")))
+    )
+    df.write_parquet(parquet_path, write_mode="overwrite")
+    print(f"  Diarization ({device}): {time.perf_counter() - t0:.1f}s")
+
+    del diarizer
+    gc.collect()
+
+    return parquet_path
+
+
+# ── Phase 3: Merge ───────────────────────────────────────────────────────────
+
+
+def find_speaker(start: float, end: float, speaker_segments: list[dict]) -> str | None:
+    """Find the speaker with maximum time overlap for the given interval."""
+    best, best_ov = None, 0.0
+    for ss in speaker_segments:
+        ov = min(end, ss["end"]) - max(start, ss["start"])
+        if ov > best_ov:
+            best_ov = ov
+            best = ss["speaker"]
+    return best
+
+
+def run_merge(dest_dir: str) -> str:
+    """Merge transcription + diarization by timestamp overlap. Returns path to parquet."""
+    import daft
+    from daft import col
+    from daft.functions import unnest
+
+    tx_path = os.path.join(dest_dir, "transcription.parquet")
+    dz_path = os.path.join(dest_dir, "diarization.parquet")
+    final_path = os.path.join(dest_dir, "final.parquet")
+
+    t0 = time.perf_counter()
+
+    tx_rows = daft.read_parquet(tx_path).collect().to_pydict()
+    dz_rows = daft.read_parquet(dz_path).collect().to_pydict()
+
+    merged_rows: dict[str, list] = {
+        "path": [],
+        "transcript": [],
+        "segments": [],
+        "info": [],
+        "speaker_segments": [],
+    }
+    for i in range(len(tx_rows["path"])):
+        segments = tx_rows["segments"][i]
+        speaker_segs = dz_rows["speaker_segments"][i]
+
+        for seg in segments:
+            if seg.get("words"):
+                for word in seg["words"]:
+                    word["speaker"] = find_speaker(word["start"], word["end"], speaker_segs)
+                speakers = [w["speaker"] for w in seg["words"] if w.get("speaker")]
+                seg["speaker"] = Counter(speakers).most_common(1)[0][0] if speakers else None
+            else:
+                seg["speaker"] = find_speaker(seg["start"], seg["end"], speaker_segs)
+
+        merged_rows["path"].append(tx_rows["path"][i])
+        merged_rows["transcript"].append(tx_rows["transcript"][i])
+        merged_rows["segments"].append(segments)
+        merged_rows["info"].append(tx_rows["info"][i])
+        merged_rows["speaker_segments"].append(speaker_segs)
+
+    daft.from_pydict(merged_rows).write_parquet(final_path, write_mode="overwrite")
+    print(f"  Merge: {time.perf_counter() - t0:.1f}s")
+
+    df_preview = (
+        daft.read_parquet(final_path)
+        .select("segments")
+        .explode("segments")
+        .select(unnest(col("segments")))
+        .select("speaker", "start", "end", "text")
+    )
+    df_preview.show()
+
+    return final_path
+
+
+# ── Phase 4: HTML Report ────────────────────────────────────────────────────
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format seconds as H:MM:SS or M:SS."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+def generate_report(dest_dir: str, source_path: str) -> str:
+    """Generate HTML report with speaker summaries and interactive renaming."""
+    import json as _json
+
+    import daft
+
+    t0 = time.perf_counter()
+    final_path = os.path.join(dest_dir, "final.parquet")
+    report_path = os.path.join(dest_dir, "report.html")
+
+    data = daft.read_parquet(final_path).collect().to_pydict()
+    segments = data["segments"][0]
+    info = data["info"][0]
+
+    speaker_durations: Counter[str] = Counter()
+    speaker_words: Counter[str] = Counter()
+    for seg in segments:
+        dur = seg["end"] - seg["start"]
+        speaker_durations[seg["speaker"]] += dur
+        speaker_words[seg["speaker"]] += len((seg.get("text") or "").split())
+
+    total_speech = sum(speaker_durations.values())
+    ranked_speakers = sorted(speaker_durations.items(), key=lambda x: -x[1])
+
+    speaker_colors = {sp: PALETTE[i] if i < len(PALETTE) else "#6b7280" for i, (sp, _) in enumerate(ranked_speakers)}
+
+    turns: list[dict] = []
+    for seg in segments:
+        if turns and turns[-1]["speaker"] == seg["speaker"]:
+            turns[-1]["end"] = seg["end"]
+            turns[-1]["text"] += " " + (seg.get("text") or "").strip()
+        else:
+            turns.append(
+                {
+                    "speaker": seg["speaker"],
+                    "start": seg["start"],
+                    "end": seg["end"],
+                    "text": (seg.get("text") or "").strip(),
+                }
+            )
+
+    source_name = os.path.basename(source_path)
+
+    speaker_table_rows = "\n".join(
+        f"      <tr>"
+        f'<td><span class="swatch" style="background:{speaker_colors[sp]}"></span>'
+        f'<input class="rename" data-speaker-id="{sp}" value="{sp}" '
+        f'style="color:{speaker_colors[sp]};font-weight:bold"></td>'
+        f"<td>{format_timestamp(dur)}</td>"
+        f"<td>{dur / total_speech * 100:.1f}%</td>"
+        f"<td>{speaker_words[sp]:,}</td></tr>"
+        for sp, dur in ranked_speakers
+    )
+
+    turn_blocks = "\n".join(
+        f'    <div class="turn">\n'
+        f'      <h3><strong class="speaker-label" data-speaker-id="{t["speaker"]}" '
+        f'style="color:{speaker_colors[t["speaker"]]}">{t["speaker"]}</strong> '
+        f"<code>[{format_timestamp(t['start'])} - {format_timestamp(t['end'])}]</code></h3>\n"
+        f"      <p>{t['text']}</p>\n"
+        f"    </div>"
+        for t in turns
+    )
+
+    template_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "report_template.html")
+    with open(template_path) as f:
+        template = f.read()
+
+    substitutions = {
+        "source_name": source_name,
+        "source_name_json": _json.dumps(source_name),
+        "storage_key_json": _json.dumps(f"diar-renames::{source_name}"),
+        "duration": format_timestamp(info["duration"]),
+        "language": info["language"],
+        "segments_count": f"{len(segments):,}",
+        "speakers_count": str(len(speaker_durations)),
+        "speaker_table_rows": speaker_table_rows,
+        "turn_blocks": turn_blocks,
+    }
+    html = template
+    for key, value in substitutions.items():
+        html = html.replace(f"{{{{{key}}}}}", str(value))
+
+    with open(report_path, "w") as f:
+        f.write(html)
+
+    elapsed = time.perf_counter() - t0
+    print(f"  Report: {elapsed:.1f}s -> {report_path}")
+    print(f"  Open with: open {report_path}")
+    return report_path
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Transcribe + diarize audio",
+        epilog="Requires HF_TOKEN env var and ffmpeg on PATH.",
+    )
+    parser.add_argument("--source", required=True, help="Path to audio file (WAV, M4A, MP3, etc.)")
+    parser.add_argument("--dest", default=DEST_DIR, help="Output directory (default: %(default)s)")
+    parser.add_argument("--no-cache", action="store_true", help="Force re-run all phases")
+    args = parser.parse_args()
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if not hf_token:
+        raise OSError("HF_TOKEN not set. Add it to .env or export it.")
+
+    os.makedirs(args.dest, exist_ok=True)
+    t_total = time.perf_counter()
+
+    print("\n[1/5] Preprocessing")
+    wav_path = ensure_wav(args.source, args.dest)
+
+    tx_parquet = os.path.join(args.dest, "transcription.parquet")
+    if not args.no_cache and os.path.exists(tx_parquet):
+        print("\n[2/5] Transcription (cached)")
+    else:
+        print("\n[2/5] Transcription")
+        run_transcription(wav_path, args.dest, BATCH_SIZE)
+
+    dz_parquet = os.path.join(args.dest, "diarization.parquet")
+    if not args.no_cache and os.path.exists(dz_parquet):
+        print("\n[3/5] Diarization (cached)")
+    else:
+        print("\n[3/5] Diarization")
+        run_diarization(wav_path, args.dest, hf_token)
+
+    print("\n[4/5] Merge")
+    run_merge(args.dest)
+
+    print("\n[5/5] Report")
+    generate_report(args.dest, args.source)
+
+    elapsed = time.perf_counter() - t_total
+    print(f"\nDone in {elapsed:.1f}s. Results at {args.dest}/final.parquet")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    main()

--- a/pipelines/transcribe_diarize/transcribe_diarize.py
+++ b/pipelines/transcribe_diarize/transcribe_diarize.py
@@ -5,6 +5,7 @@
 #     "daft>=0.7.8",
 #     "faster-whisper",
 #     "pyannote.audio",
+#     "pyiceberg[sql-sqlite]",
 #     "python-dotenv",
 #     "torch",
 #     "torchaudio",
@@ -17,20 +18,22 @@ Transcribes audio with faster-whisper, diarizes speakers with pyannote.audio,
 and merges the results so every word and segment is attributed to a speaker.
 
 Architecture:
-  Phase 1 — Transcribe (faster-whisper, CPU)  → transcription.parquet
-  Phase 2 — Diarize   (pyannote 3.1, MPS/GPU) → diarization.parquet
-  Phase 3 — Merge     (timestamp overlap)      → final.parquet
+  Phase 1 — Transcribe (faster-whisper, CPU)  → transcribe_diarize.transcription
+  Phase 2 — Diarize   (pyannote 3.1, MPS/GPU) → transcribe_diarize.diarization
+  Phase 3 — Merge     (timestamp overlap)      → transcribe_diarize.merged
   Phase 4 — Report    (HTML generation)        → report.html
 
 Phases run sequentially so models don't compete for memory.
-Intermediate parquets are cached — rerun skips completed phases.
-
-Audio is converted to 16 kHz mono WAV before processing (pyannote
-requires exact sample counts that lossy formats like MP3/M4A can't guarantee).
+Results are stored as Iceberg tables in the shared catalog (see pipelines/catalog.py).
+Cache validation is source-aware — switching audio files invalidates stale tables.
 
 Requirements:
   - HF_TOKEN env var (pyannote requires Hugging Face authentication)
   - ffmpeg on PATH (for non-WAV audio conversion)
+
+Configuration:
+  DAFT_WAREHOUSE  — catalog warehouse path (default: .data/warehouse)
+  See pipelines/README.md for full catalog configuration.
 
 Usage:
   uv run transcribe_diarize.py --source /path/to/audio.m4a
@@ -40,14 +43,23 @@ Usage:
 
 import argparse
 import gc
+import hashlib
+import html
 import os
 import subprocess
+import sys
 import time
 from collections import Counter
 from dataclasses import asdict
+from pathlib import Path
 
 from dotenv import load_dotenv
 
+_PIPELINES_DIR = str(Path(__file__).resolve().parent.parent)
+if _PIPELINES_DIR not in sys.path:
+    sys.path.insert(0, _PIPELINES_DIR)
+
+NAMESPACE = "transcribe_diarize"
 DEST_DIR = ".data/transcribe_diarize"
 BATCH_SIZE = 16
 PALETTE = [
@@ -62,13 +74,45 @@ PALETTE = [
 ]
 
 
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def source_fingerprint(path: str) -> str:
+    """Short hash of the absolute source path for cache disambiguation."""
+    return hashlib.sha256(os.path.abspath(path).encode()).hexdigest()[:8]
+
+
+def write_to_catalog(catalog, table_id: str, df) -> None:
+    """Write a DataFrame to a catalog table, creating it if it doesn't exist."""
+    if catalog.has_table(table_id):
+        catalog.write_table(table_id, df, mode="overwrite")
+    else:
+        catalog.create_table(table_id, df)
+
+
+def is_cached_for_source(catalog, table_id: str, wav_path: str) -> bool:
+    """Check if a table exists and was produced from the same source audio."""
+    if not catalog.has_table(table_id):
+        return False
+    try:
+        cached = catalog.read_table(table_id).select("path").limit(1).collect().to_pydict()
+        return cached["path"][0] == wav_path
+    except Exception:
+        return False
+
+
 # ── Audio Preprocessing ─────────────────────────────────────────────────────
 
 
 def ensure_wav(source: str, dest_dir: str) -> str:
-    """Convert audio to 16 kHz mono WAV if not already WAV."""
+    """Convert audio to 16 kHz mono WAV if not already WAV.
+
+    WAV filename includes a source-path fingerprint to prevent collisions
+    when different inputs share the same basename.
+    """
     basename = os.path.splitext(os.path.basename(source))[0]
-    wav_path = os.path.join(dest_dir, f"{basename}.wav")
+    fingerprint = source_fingerprint(source)
+    wav_path = os.path.join(dest_dir, f"{basename}_{fingerprint}.wav")
 
     if os.path.exists(wav_path):
         print(f"  Using cached WAV: {wav_path}")
@@ -94,8 +138,8 @@ def ensure_wav(source: str, dest_dir: str) -> str:
 # freeing memory before diarization starts.
 
 
-def run_transcription(wav_path: str, dest_dir: str, batch_size: int) -> str:
-    """Transcribe audio with faster-whisper. Returns path to parquet."""
+def run_transcription(wav_path: str, catalog, batch_size: int) -> None:
+    """Transcribe audio with faster-whisper. Writes to catalog table."""
     from diarize_schema import DiarizedSegmentStruct, InfoStruct
     from faster_whisper import BatchedInferencePipeline, WhisperModel
 
@@ -103,7 +147,7 @@ def run_transcription(wav_path: str, dest_dir: str, batch_size: int) -> str:
     from daft import DataType, col
     from daft.functions import file, unnest
 
-    parquet_path = os.path.join(dest_dir, "transcription.parquet")
+    table_id = f"{NAMESPACE}.transcription"
 
     TranscriptionResult = DataType.struct(
         {
@@ -149,20 +193,18 @@ def run_transcription(wav_path: str, dest_dir: str, batch_size: int) -> str:
         .with_column("result", transcriber.transcribe(col("audio_file")))
         .select("path", unnest(col("result")))
     )
-    df.write_parquet(parquet_path, write_mode="overwrite")
+    write_to_catalog(catalog, table_id, df)
     print(f"  Transcription: {time.perf_counter() - t0:.1f}s")
 
     del transcriber
     gc.collect()
 
-    return parquet_path
-
 
 # ── Phase 2: Diarization ────────────────────────────────────────────────────
 
 
-def run_diarization(wav_path: str, dest_dir: str, hf_token: str) -> str:
-    """Diarize speakers with pyannote. Returns path to parquet."""
+def run_diarization(wav_path: str, catalog, hf_token: str) -> None:
+    """Diarize speakers with pyannote. Writes to catalog table."""
     import torch
     from diarize_schema import SpeakerSegmentStruct
     from pyannote.audio import Pipeline
@@ -171,7 +213,7 @@ def run_diarization(wav_path: str, dest_dir: str, hf_token: str) -> str:
     from daft import DataType, col
     from daft.functions import file
 
-    parquet_path = os.path.join(dest_dir, "diarization.parquet")
+    table_id = f"{NAMESPACE}.diarization"
 
     device = "mps" if torch.backends.mps.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -204,13 +246,11 @@ def run_diarization(wav_path: str, dest_dir: str, hf_token: str) -> str:
         .with_column("audio_file", file(col("path")))
         .with_column("speaker_segments", diarizer.diarize(col("audio_file")))
     )
-    df.write_parquet(parquet_path, write_mode="overwrite")
+    write_to_catalog(catalog, table_id, df)
     print(f"  Diarization ({device}): {time.perf_counter() - t0:.1f}s")
 
     del diarizer
     gc.collect()
-
-    return parquet_path
 
 
 # ── Phase 3: Merge ───────────────────────────────────────────────────────────
@@ -227,20 +267,16 @@ def find_speaker(start: float, end: float, speaker_segments: list[dict]) -> str 
     return best
 
 
-def run_merge(dest_dir: str) -> str:
-    """Merge transcription + diarization by timestamp overlap. Returns path to parquet."""
+def run_merge(catalog) -> None:
+    """Merge transcription + diarization by timestamp overlap. Writes to catalog table."""
     import daft
     from daft import col
     from daft.functions import unnest
 
-    tx_path = os.path.join(dest_dir, "transcription.parquet")
-    dz_path = os.path.join(dest_dir, "diarization.parquet")
-    final_path = os.path.join(dest_dir, "final.parquet")
-
     t0 = time.perf_counter()
 
-    tx_rows = daft.read_parquet(tx_path).collect().to_pydict()
-    dz_rows = daft.read_parquet(dz_path).collect().to_pydict()
+    tx_rows = catalog.read_table(f"{NAMESPACE}.transcription").collect().to_pydict()
+    dz_rows = catalog.read_table(f"{NAMESPACE}.diarization").collect().to_pydict()
 
     merged_rows: dict[str, list] = {
         "path": [],
@@ -268,19 +304,17 @@ def run_merge(dest_dir: str) -> str:
         merged_rows["info"].append(tx_rows["info"][i])
         merged_rows["speaker_segments"].append(speaker_segs)
 
-    daft.from_pydict(merged_rows).write_parquet(final_path, write_mode="overwrite")
+    write_to_catalog(catalog, f"{NAMESPACE}.merged", daft.from_pydict(merged_rows))
     print(f"  Merge: {time.perf_counter() - t0:.1f}s")
 
     df_preview = (
-        daft.read_parquet(final_path)
+        catalog.read_table(f"{NAMESPACE}.merged")
         .select("segments")
         .explode("segments")
         .select(unnest(col("segments")))
         .select("speaker", "start", "end", "text")
     )
     df_preview.show()
-
-    return final_path
 
 
 # ── Phase 4: HTML Report ────────────────────────────────────────────────────
@@ -294,17 +328,14 @@ def format_timestamp(seconds: float) -> str:
     return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
 
 
-def generate_report(dest_dir: str, source_path: str) -> str:
+def generate_report(catalog, dest_dir: str, source_path: str) -> str:
     """Generate HTML report with speaker summaries and interactive renaming."""
     import json as _json
 
-    import daft
-
     t0 = time.perf_counter()
-    final_path = os.path.join(dest_dir, "final.parquet")
     report_path = os.path.join(dest_dir, "report.html")
 
-    data = daft.read_parquet(final_path).collect().to_pydict()
+    data = catalog.read_table(f"{NAMESPACE}.merged").collect().to_pydict()
     segments = data["segments"][0]
     info = data["info"][0]
 
@@ -336,11 +367,12 @@ def generate_report(dest_dir: str, source_path: str) -> str:
             )
 
     source_name = os.path.basename(source_path)
+    safe_source = html.escape(source_name)
 
     speaker_table_rows = "\n".join(
         f"      <tr>"
         f'<td><span class="swatch" style="background:{speaker_colors[sp]}"></span>'
-        f'<input class="rename" data-speaker-id="{sp}" value="{sp}" '
+        f'<input class="rename" data-speaker-id="{html.escape(sp)}" value="{html.escape(sp)}" '
         f'style="color:{speaker_colors[sp]};font-weight:bold"></td>'
         f"<td>{format_timestamp(dur)}</td>"
         f"<td>{dur / total_speech * 100:.1f}%</td>"
@@ -350,10 +382,10 @@ def generate_report(dest_dir: str, source_path: str) -> str:
 
     turn_blocks = "\n".join(
         f'    <div class="turn">\n'
-        f'      <h3><strong class="speaker-label" data-speaker-id="{t["speaker"]}" '
-        f'style="color:{speaker_colors[t["speaker"]]}">{t["speaker"]}</strong> '
+        f'      <h3><strong class="speaker-label" data-speaker-id="{html.escape(t["speaker"] or "")}" '
+        f'style="color:{speaker_colors[t["speaker"]]}">{html.escape(t["speaker"] or "")}</strong> '
         f"<code>[{format_timestamp(t['start'])} - {format_timestamp(t['end'])}]</code></h3>\n"
-        f"      <p>{t['text']}</p>\n"
+        f"      <p>{html.escape(t['text'])}</p>\n"
         f"    </div>"
         for t in turns
     )
@@ -363,22 +395,22 @@ def generate_report(dest_dir: str, source_path: str) -> str:
         template = f.read()
 
     substitutions = {
-        "source_name": source_name,
+        "source_name": safe_source,
         "source_name_json": _json.dumps(source_name),
         "storage_key_json": _json.dumps(f"diar-renames::{source_name}"),
         "duration": format_timestamp(info["duration"]),
-        "language": info["language"],
+        "language": html.escape(info["language"]),
         "segments_count": f"{len(segments):,}",
         "speakers_count": str(len(speaker_durations)),
         "speaker_table_rows": speaker_table_rows,
         "turn_blocks": turn_blocks,
     }
-    html = template
+    rendered = template
     for key, value in substitutions.items():
-        html = html.replace(f"{{{{{key}}}}}", str(value))
+        rendered = rendered.replace(f"{{{{{key}}}}}", str(value))
 
     with open(report_path, "w") as f:
-        f.write(html)
+        f.write(rendered)
 
     elapsed = time.perf_counter() - t0
     print(f"  Report: {elapsed:.1f}s -> {report_path}")
@@ -390,12 +422,14 @@ def generate_report(dest_dir: str, source_path: str) -> str:
 
 
 def main():
+    from catalog import ensure_namespace
+
     parser = argparse.ArgumentParser(
         description="Transcribe + diarize audio",
         epilog="Requires HF_TOKEN env var and ffmpeg on PATH.",
     )
     parser.add_argument("--source", required=True, help="Path to audio file (WAV, M4A, MP3, etc.)")
-    parser.add_argument("--dest", default=DEST_DIR, help="Output directory (default: %(default)s)")
+    parser.add_argument("--dest", default=DEST_DIR, help="Report output directory (default: %(default)s)")
     parser.add_argument("--no-cache", action="store_true", help="Force re-run all phases")
     args = parser.parse_args()
 
@@ -404,33 +438,36 @@ def main():
         raise OSError("HF_TOKEN not set. Add it to .env or export it.")
 
     os.makedirs(args.dest, exist_ok=True)
+    catalog = ensure_namespace(NAMESPACE)
     t_total = time.perf_counter()
 
     print("\n[1/5] Preprocessing")
     wav_path = ensure_wav(args.source, args.dest)
 
-    tx_parquet = os.path.join(args.dest, "transcription.parquet")
-    if not args.no_cache and os.path.exists(tx_parquet):
+    tx_table = f"{NAMESPACE}.transcription"
+    if not args.no_cache and is_cached_for_source(catalog, tx_table, wav_path):
         print("\n[2/5] Transcription (cached)")
     else:
         print("\n[2/5] Transcription")
-        run_transcription(wav_path, args.dest, BATCH_SIZE)
+        run_transcription(wav_path, catalog, BATCH_SIZE)
 
-    dz_parquet = os.path.join(args.dest, "diarization.parquet")
-    if not args.no_cache and os.path.exists(dz_parquet):
+    dz_table = f"{NAMESPACE}.diarization"
+    if not args.no_cache and is_cached_for_source(catalog, dz_table, wav_path):
         print("\n[3/5] Diarization (cached)")
     else:
         print("\n[3/5] Diarization")
-        run_diarization(wav_path, args.dest, hf_token)
+        run_diarization(wav_path, catalog, hf_token)
 
     print("\n[4/5] Merge")
-    run_merge(args.dest)
+    run_merge(catalog)
 
     print("\n[5/5] Report")
-    generate_report(args.dest, args.source)
+    generate_report(catalog, args.dest, args.source)
 
     elapsed = time.perf_counter() - t_total
-    print(f"\nDone in {elapsed:.1f}s. Results at {args.dest}/final.parquet")
+    print(f"\nDone in {elapsed:.1f}s")
+    print(f"  Tables: {tx_table}, {dz_table}, {NAMESPACE}.merged")
+    print(f"  Report: {args.dest}/report.html")
 
 
 if __name__ == "__main__":

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -117,6 +117,8 @@ SCRIPTS: list[Script] = [
     Script("pipelines/social_recommendation/ingest_images.py",      env=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"], tier="pipeline"),
     Script("pipelines/social_recommendation/write_index_to_uc.py",  env=["DATABRICKS_TOKEN"], tier="pipeline", skip="daft.unity_catalog module not available in daft 0.7.8"),
 
+    Script("pipelines/transcribe_diarize/transcribe_diarize.py",  env=["HF_TOKEN"], tier="pipeline", timeout=300, skip="requires faster-whisper + pyannote model download"),
+
     Script("pipelines/voice_ai_analytics/voice_ai_analytics.py",        env=["OPENROUTER_API_KEY"], tier="pipeline", timeout=300, skip="requires faster-whisper model download"),
     Script("pipelines/voice_ai_analytics/voice_ai_analytics_openai.py",  env=["OPENAI_API_KEY"], tier="pipeline"),
     Script("pipelines/voice_ai_analytics/voice_ai_tutorial.py",          tier="pipeline", skip="requires faster-whisper model download"),


### PR DESCRIPTION
## Summary

- Adds a four-phase audio pipeline: **faster-whisper transcription → pyannote speaker diarization → timestamp-overlap merge → interactive HTML report**
- Phases run sequentially with deferred imports so Whisper and pyannote models don't compete for memory; intermediate parquets are cached across runs
- HTML report features color-coded speakers, editable names (persisted in localStorage), and "Copy as Markdown" export

### Cleanup from prototype

- Removed hardcoded local path (`/Users/.../Desktop/...`) — `--source` is now required
- Fixed duplicate `# ── Main ──` section header
- Added module docstring to `diarize_schema.py`
- `EnvironmentError` → `OSError` per ruff UP024
- Import ordering fixed for ruff I001
- Registered in test suite (skipped in CI: requires model download + HF_TOKEN)
- Updated `CONTRIBUTING.md` repo structure to include `transcribe_diarize/`

## Test plan

- [ ] Syntax verified: `python -c "import ast; ast.parse(...)"`
- [ ] No hardcoded local paths: `grep -r '/Users\|~/\|Desktop' pipelines/transcribe_diarize/` returns nothing
- [ ] `ruff check` and `ruff format --check` pass (pre-commit hook verified)
- [ ] Registered in `tests/registry.py` with `skip="requires faster-whisper + pyannote model download"`
- [ ] Manual run: `uv run pipelines/transcribe_diarize/transcribe_diarize.py --source <audio.m4a>` (requires HF_TOKEN + ffmpeg)


Made with [Cursor](https://cursor.com)