### PR TITLE
Add examples/session: canonical patterns for sessions, catalogs, providers, and extensions

### DIFF
--- a/examples/session/session_basics.py
+++ b/examples/session/session_basics.py
@@ -1,0 +1,48 @@
+# /// script
+# description = "Session basics - creation, context manager, and state management"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+import daft
+from daft import Session, Table
+
+
+def explicit_session() -> None:
+    """Create a standalone session. Attach/read operations are scoped to it and don't touch the global default."""
+    sess = Session()
+    sess.attach_table(
+        Table.from_df("students", daft.from_pydict({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})),
+    )
+    sess.read_table("students").show()
+
+
+def context_manager_session() -> None:
+    """Use a session as a context manager to set it as the active global session for the block."""
+    with daft.session() as sess:
+        sess.attach_table(
+            Table.from_df(
+                "cities",
+                daft.from_pydict({"city": ["NYC", "SF", "LA"], "pop": [8_336_817, 808_437, 3_898_747]}),
+            ),
+        )
+        # daft.read_table resolves through the active session
+        daft.read_table("cities").show()
+
+
+def global_session() -> None:
+    """Operate on the default global session via module-level helpers."""
+    daft.attach_table(
+        Table.from_df(
+            "languages",
+            daft.from_pydict({"lang": ["Python", "Rust", "SQL"], "year": [1991, 2010, 1974]}),
+        ),
+    )
+    daft.read_table("languages").show()
+    daft.detach_table("languages")
+
+
+if __name__ == "__main__":
+    explicit_session()
+    context_manager_session()
+    global_session()

--- a/examples/session/session_catalogs.py
+++ b/examples/session/session_catalogs.py
@@ -1,0 +1,81 @@
+# /// script
+# description = "Session catalogs - attach catalogs, create tables, and manage existence"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+import daft
+from daft import Catalog, Session
+
+
+def build_shop_catalog() -> Catalog:
+    """Wrap a dict of tables into a named in-memory Catalog."""
+    return Catalog.from_pydict(
+        {
+            "users": {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]},
+            "orders": {"order_id": [10, 20], "user_id": [1, 2], "amount": [99.99, 149.50]},
+        },
+        name="shop",
+    )
+
+
+def attach_to_session(catalog: Catalog) -> Session:
+    """Attach a catalog to a session and set it as active."""
+    sess = Session()
+    sess.attach_catalog(catalog)
+    sess.set_catalog("shop")
+    sess.read_table("users").show()
+    return sess
+
+
+def attach_globally(catalog: Catalog) -> None:
+    """Attach a catalog to the global default session."""
+    daft.attach_catalog(catalog)
+    daft.set_catalog("shop")
+    daft.read_table("users").show()
+
+
+def create_table(sess: Session) -> None:
+    """Create a new persistent table in the active catalog from a DataFrame."""
+    tiers = daft.from_pydict({"user_id": [1, 2, 3], "tier": ["gold", "silver", "bronze"]})
+    sess.create_table("tiers", tiers)
+    sess.read_table("tiers").show()
+
+
+def create_temp_table(sess: Session) -> None:
+    """Create a session-scoped temp table that doesn't persist to the catalog."""
+    scratch = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    sess.create_temp_table("scratch", scratch)
+    sess.read_table("scratch").show()
+
+
+def existence_checks(sess: Session) -> None:
+    """Check for catalogs and tables before acting on them."""
+    sess.has_catalog("shop")
+    sess.has_table("users")
+    sess.has_table("missing")
+
+
+def external_catalog_factories() -> None:
+    """Reference for connecting Daft to external catalog systems.
+
+    Each factory requires real credentials - shown here as documentation:
+
+        Catalog.from_unity(unity_client)                      # Databricks Unity Catalog
+        Catalog.from_iceberg(pyiceberg_catalog)               # Apache Iceberg (PyIceberg)
+        Catalog.from_glue("my_glue_db")                       # AWS Glue
+        Catalog.from_s3tables(table_bucket_arn="arn:aws:..")  # AWS S3 Tables
+        Catalog.from_postgres("postgresql://user:pass@host")  # PostgreSQL
+        Catalog.from_gravitino(endpoint="http://...")         # Apache Gravitino
+        Catalog.from_paimon(paimon_catalog)                   # Apache Paimon
+    """
+
+
+if __name__ == "__main__":
+    catalog = build_shop_catalog()
+    sess = attach_to_session(catalog)
+    attach_globally(catalog)
+    create_table(sess)
+    create_temp_table(sess)
+    existence_checks(sess)
+    external_catalog_factories()

--- a/examples/session/session_catalogs.py
+++ b/examples/session/session_catalogs.py
@@ -51,9 +51,9 @@ def create_temp_table(sess: Session) -> None:
 
 def existence_checks(sess: Session) -> None:
     """Check for catalogs and tables before acting on them."""
-    sess.has_catalog("shop")
-    sess.has_table("users")
-    sess.has_table("missing")
+    print(f"has_catalog('shop'):   {sess.has_catalog('shop')}")
+    print(f"has_table('users'):    {sess.has_table('users')}")
+    print(f"has_table('missing'):  {sess.has_table('missing')}")
 
 
 def external_catalog_factories() -> None:

--- a/examples/session/session_context_config.py
+++ b/examples/session/session_context_config.py
@@ -18,6 +18,8 @@ def anonymous_s3_io_config() -> IOConfig:
 def enable_dynamic_batching() -> None:
     """Enable dynamic batching globally to optimize batch sizes for AI/GPU workloads."""
     daft.set_execution_config(enable_dynamic_batching=True)
+    ctx = daft.get_context()
+    print(f"dynamic_batching: {ctx.daft_execution_config.enable_dynamic_batching}")
 
 
 def set_default_io_config(io_config: IOConfig) -> None:
@@ -46,11 +48,16 @@ def fine_tuned_execution_config() -> None:
         shuffle_aggregation_default_partitions=16,
         default_morsel_size=1024,
     )
+    ctx = daft.get_context()
+    print(f"num_preview_rows:    {ctx.daft_execution_config.num_preview_rows}")
+    print(f"default_morsel_size: {ctx.daft_execution_config.default_morsel_size}")
 
 
 def enable_strict_filter_pushdown() -> None:
     """Enable strict filter pushdown for Parquet/Delta/Iceberg predicate optimization."""
     daft.set_planning_config(enable_strict_filter_pushdown=True)
+    ctx = daft.get_context()
+    print(f"strict_filter_pushdown: {ctx.daft_planning_config.enable_strict_filter_pushdown}")
 
 
 if __name__ == "__main__":

--- a/examples/session/session_context_config.py
+++ b/examples/session/session_context_config.py
@@ -1,0 +1,64 @@
+# /// script
+# description = "Session context config - execution settings, planning config, and IO config"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+import daft
+from daft.io import IOConfig, S3Config
+
+PUBLIC_PARQUET = "s3://daft-public-data/tutorials/laion-parquet/train-00000-of-00001-6f24a7497df494ae.parquet"
+
+
+def anonymous_s3_io_config() -> IOConfig:
+    """Return an IOConfig for anonymous access to public S3 datasets."""
+    return IOConfig(s3=S3Config(anonymous=True, region_name="us-east-1"))
+
+
+def enable_dynamic_batching() -> None:
+    """Enable dynamic batching globally to optimize batch sizes for AI/GPU workloads."""
+    daft.set_execution_config(enable_dynamic_batching=True)
+
+
+def set_default_io_config(io_config: IOConfig) -> None:
+    """Set a default IOConfig so every read uses it without passing io_config= explicitly."""
+    daft.set_planning_config(default_io_config=io_config)
+    daft.read_parquet(PUBLIC_PARQUET).limit(5).show()
+
+
+def scoped_execution_config() -> None:
+    """Apply execution config for a single block, then restore the previous settings."""
+    with daft.execution_config_ctx(enable_dynamic_batching=True, num_preview_rows=3):
+        daft.from_pydict({"x": list(range(10))}).show()
+
+
+def scoped_planning_config(io_config: IOConfig) -> None:
+    """Apply planning config for a single block, then restore the previous settings."""
+    with daft.planning_config_ctx(default_io_config=io_config):
+        daft.read_parquet(PUBLIC_PARQUET).limit(3).show()
+
+
+def fine_tuned_execution_config() -> None:
+    """Set multiple execution knobs at once for advanced tuning."""
+    daft.set_execution_config(
+        enable_dynamic_batching=True,
+        num_preview_rows=5,
+        shuffle_aggregation_default_partitions=16,
+        default_morsel_size=1024,
+    )
+
+
+def enable_strict_filter_pushdown() -> None:
+    """Enable strict filter pushdown for Parquet/Delta/Iceberg predicate optimization."""
+    daft.set_planning_config(enable_strict_filter_pushdown=True)
+
+
+if __name__ == "__main__":
+    io_config = anonymous_s3_io_config()
+
+    enable_dynamic_batching()
+    set_default_io_config(io_config)
+    scoped_execution_config()
+    scoped_planning_config(io_config)
+    fine_tuned_execution_config()
+    enable_strict_filter_pushdown()

--- a/examples/session/session_extension_h3.py
+++ b/examples/session/session_extension_h3.py
@@ -1,0 +1,105 @@
+# /// script
+# description = "Native extension via load_extension() - daft-h3 for H3 geospatial indexing"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8", "daft-h3"]
+# ///
+
+import daft
+import daft_h3
+from daft import Session, col
+
+
+def load_h3_extension() -> Session:
+    """Register the daft-h3 native extension with a session.
+
+    load_extension takes the extension's Python module, links its shared
+    library, and makes its Rust-native functions available inside the session.
+    """
+    sess = Session()
+    sess.load_extension(daft_h3)
+    return sess
+
+
+def cities() -> daft.DataFrame:
+    """Sample DataFrame of cities with latitude/longitude."""
+    return daft.from_pydict(
+        {
+            "city": ["San Francisco", "Paris", "Tokyo", "New York"],
+            "lat": [37.7749, 48.8566, 35.6762, 40.7128],
+            "lng": [-122.4194, 2.3522, 139.6503, -74.0060],
+        }
+    )
+
+
+def latlng_to_cells(df: daft.DataFrame) -> daft.DataFrame:
+    """Encode lat/lng pairs as H3 cells at two different resolutions."""
+    return df.select(
+        col("city"),
+        daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 7).alias("cell_r7"),
+        daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 9).alias("cell_r9"),
+    )
+
+
+def cells_to_hex(df: daft.DataFrame) -> daft.DataFrame:
+    """Convert UInt64 cell indices to human-readable hex strings.
+
+    Operate on UInt64 in hot paths; convert to hex only for display or export.
+    """
+    return df.select(
+        col("city"),
+        daft_h3.h3_cell_to_str(col("cell_r7")).alias("hex_r7"),
+        daft_h3.h3_cell_to_str(col("cell_r9")).alias("hex_r9"),
+    )
+
+
+def inspect_cells(df: daft.DataFrame) -> daft.DataFrame:
+    """Derive resolution, validity, and center lat/lng from cell indices."""
+    return df.select(
+        col("city"),
+        col("hex_r9"),
+        daft_h3.h3_cell_resolution(col("hex_r9")).alias("resolution"),
+        daft_h3.h3_cell_is_valid(col("hex_r9")).alias("is_valid"),
+        daft_h3.h3_cell_to_lat(col("hex_r9")).alias("center_lat"),
+        daft_h3.h3_cell_to_lng(col("hex_r9")).alias("center_lng"),
+    )
+
+
+def rollup_to_parents(df: daft.DataFrame) -> daft.DataFrame:
+    """Climb the H3 hierarchy to coarser resolutions for multi-zoom aggregation."""
+    return df.select(
+        col("city"),
+        col("hex_r9"),
+        daft_h3.h3_cell_to_str(daft_h3.h3_cell_parent(col("hex_r9"), 5)).alias("parent_r5"),
+        daft_h3.h3_cell_to_str(daft_h3.h3_cell_parent(col("hex_r9"), 3)).alias("parent_r3"),
+    )
+
+
+def grid_distance() -> daft.DataFrame:
+    """Compute hop distance between H3 cells at the same resolution."""
+    pairs = daft.from_pydict(
+        {
+            "from_city": ["SF", "SF", "NYC"],
+            "to_city":   ["NYC", "LA", "LA"],
+            "from_hex":  ["8928308280fffff", "8928308280fffff", "89283470d93ffff"],
+            "to_hex":    ["89283470d93ffff", "8928347606bffff", "8928347606bffff"],
+        }
+    )
+    return pairs.select(
+        col("from_city"),
+        col("to_city"),
+        daft_h3.h3_grid_distance(col("from_hex"), col("to_hex")).alias("hops"),
+    )
+
+
+if __name__ == "__main__":
+    sess = load_h3_extension()
+    with sess:
+        df = latlng_to_cells(cities())
+        df.show()
+
+        df = cells_to_hex(df)
+        df.show()
+
+        inspect_cells(df).show()
+        rollup_to_parents(df).show()
+        grid_distance().show()

--- a/examples/session/session_extension_h3.py
+++ b/examples/session/session_extension_h3.py
@@ -4,8 +4,9 @@
 # dependencies = ["daft>=0.7.8", "daft-h3"]
 # ///
 
-import daft
 import daft_h3
+
+import daft
 from daft import Session, col
 
 

--- a/examples/session/session_extension_h3.py
+++ b/examples/session/session_extension_h3.py
@@ -80,9 +80,9 @@ def grid_distance() -> daft.DataFrame:
     pairs = daft.from_pydict(
         {
             "from_city": ["SF", "SF", "NYC"],
-            "to_city":   ["NYC", "LA", "LA"],
-            "from_hex":  ["8928308280fffff", "8928308280fffff", "89283470d93ffff"],
-            "to_hex":    ["89283470d93ffff", "8928347606bffff", "8928347606bffff"],
+            "to_city": ["NYC", "LA", "LA"],
+            "from_hex": ["8928308280fffff", "8928308280fffff", "89283470d93ffff"],
+            "to_hex": ["89283470d93ffff", "8928347606bffff", "8928347606bffff"],
         }
     )
     return pairs.select(

--- a/examples/session/session_namespaces.py
+++ b/examples/session/session_namespaces.py
@@ -21,6 +21,7 @@ def create_namespaces(sess: Session) -> None:
     sess.create_namespace("sales")
     sess.create_namespace("marketing")
     sess.create_namespace_if_not_exists("sales")  # idempotent
+    print(f"namespaces: {sess.list_namespaces()}")
 
 
 def create_tables_in_namespaces(sess: Session) -> None:
@@ -37,6 +38,7 @@ def create_tables_in_namespaces(sess: Session) -> None:
         "marketing.campaigns",
         daft.from_pydict({"campaign_id": [100, 101], "name": ["Spring", "Summer"]}),
     )
+    print(f"tables: {sess.list_tables()}")
 
 
 def read_fully_qualified(sess: Session) -> None:
@@ -48,32 +50,37 @@ def read_fully_qualified(sess: Session) -> None:
 def set_active_namespace(sess: Session) -> None:
     """Set an active namespace so unqualified names resolve within it."""
     sess.set_namespace("sales")
+    print(f"active namespace: {sess.current_namespace()}")
     sess.read_table("orders").show()  # resolves to sales.orders
     sess.set_namespace(None)
+    print(f"active namespace: {sess.current_namespace()}")
 
 
 def read_with_identifier(sess: Session) -> None:
     """Use Identifier objects for programmatic multi-part table names."""
     ident = Identifier("sales", "orders")
+    print(f"identifier: {ident!r}  parts: {list(ident)}")
     sess.read_table(ident).show()
 
 
 def existence_checks(sess: Session) -> None:
     """Check for namespaces and tables before creating or dropping them."""
-    sess.has_namespace("sales")
-    sess.has_namespace("missing")
-    sess.has_table("sales.orders")
+    print(f"has_namespace('sales'):     {sess.has_namespace('sales')}")
+    print(f"has_namespace('missing'):   {sess.has_namespace('missing')}")
+    print(f"has_table('sales.orders'):  {sess.has_table('sales.orders')}")
 
 
 def pattern_filtered_listing(sess: Session) -> None:
     """Filter catalog listings with a glob pattern."""
-    sess.list_tables("sales.*")
+    print(f"tables matching 'sales.*': {sess.list_tables('sales.*')}")
 
 
 def drop_namespace_and_tables(sess: Session) -> None:
     """Drop tables first, then their parent namespace."""
     sess.drop_table("marketing.campaigns")
     sess.drop_namespace("marketing")
+    print(f"namespaces after drop: {sess.list_namespaces()}")
+    print(f"tables after drop:     {sess.list_tables()}")
 
 
 def backend_support_notes() -> None:

--- a/examples/session/session_namespaces.py
+++ b/examples/session/session_namespaces.py
@@ -1,0 +1,99 @@
+# /// script
+# description = "Session namespaces - organize tables into logical groups within a catalog"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+import daft
+from daft import Catalog, Identifier, Session
+
+
+def build_warehouse_session() -> Session:
+    """Attach an empty in-memory catalog to a session for namespace demos."""
+    sess = Session()
+    sess.attach_catalog(Catalog.from_pydict({}, name="warehouse"))
+    sess.set_catalog("warehouse")
+    return sess
+
+
+def create_namespaces(sess: Session) -> None:
+    """Create namespaces to group related tables, like schemas in a database."""
+    sess.create_namespace("sales")
+    sess.create_namespace("marketing")
+    sess.create_namespace_if_not_exists("sales")  # idempotent
+
+
+def create_tables_in_namespaces(sess: Session) -> None:
+    """Create tables with dotted identifiers that place them inside a namespace."""
+    sess.create_table(
+        "sales.orders",
+        daft.from_pydict({"order_id": [1, 2, 3], "amount": [99.99, 149.50, 29.99]}),
+    )
+    sess.create_table(
+        "sales.customers",
+        daft.from_pydict({"customer_id": [1, 2], "name": ["Alice", "Bob"]}),
+    )
+    sess.create_table(
+        "marketing.campaigns",
+        daft.from_pydict({"campaign_id": [100, 101], "name": ["Spring", "Summer"]}),
+    )
+
+
+def read_fully_qualified(sess: Session) -> None:
+    """Read tables by their fully-qualified namespace.table name."""
+    sess.read_table("sales.orders").show()
+    sess.read_table("marketing.campaigns").show()
+
+
+def set_active_namespace(sess: Session) -> None:
+    """Set an active namespace so unqualified names resolve within it."""
+    sess.set_namespace("sales")
+    sess.read_table("orders").show()  # resolves to sales.orders
+    sess.set_namespace(None)
+
+
+def read_with_identifier(sess: Session) -> None:
+    """Use Identifier objects for programmatic multi-part table names."""
+    ident = Identifier("sales", "orders")
+    sess.read_table(ident).show()
+
+
+def existence_checks(sess: Session) -> None:
+    """Check for namespaces and tables before creating or dropping them."""
+    sess.has_namespace("sales")
+    sess.has_namespace("missing")
+    sess.has_table("sales.orders")
+
+
+def pattern_filtered_listing(sess: Session) -> None:
+    """Filter catalog listings with a glob pattern."""
+    sess.list_tables("sales.*")
+
+
+def drop_namespace_and_tables(sess: Session) -> None:
+    """Drop tables first, then their parent namespace."""
+    sess.drop_table("marketing.campaigns")
+    sess.drop_namespace("marketing")
+
+
+def backend_support_notes() -> None:
+    """Namespace operations vary by backend.
+
+    Support matrix:
+        In-memory (from_pydict):    full support
+        Iceberg, Glue, Postgres:    full support
+        Unity Catalog:              read-only (use pre-existing schemas)
+    """
+
+
+if __name__ == "__main__":
+    sess = build_warehouse_session()
+    create_namespaces(sess)
+    create_tables_in_namespaces(sess)
+    read_fully_qualified(sess)
+    set_active_namespace(sess)
+    read_with_identifier(sess)
+    existence_checks(sess)
+    pattern_filtered_listing(sess)
+    drop_namespace_and_tables(sess)
+    backend_support_notes()

--- a/examples/session/session_providers.py
+++ b/examples/session/session_providers.py
@@ -28,6 +28,7 @@ def custom_endpoint_provider() -> None:
         api_key=os.environ.get("OPENROUTER_API_KEY", ""),
         base_url="https://openrouter.ai/api/v1",
     )
+    print(f"active provider: {daft.current_provider().name}")
 
 
 def named_provider_objects() -> Session:
@@ -41,13 +42,17 @@ def named_provider_objects() -> Session:
             api_key=os.environ.get("OPENROUTER_API_KEY", ""),
         )
     )
+    print(f"has OpenAI:     {sess.has_provider('OpenAI')}")
+    print(f"has OpenRouter: {sess.has_provider('OpenRouter')}")
     return sess
 
 
 def switch_active_provider(sess: Session) -> None:
     """Switch the session's active provider without detaching or reconfiguring."""
     sess.set_provider("OpenAI")
+    print(f"active provider: {sess.current_provider().name}")
     sess.set_provider("OpenRouter")
+    print(f"active provider: {sess.current_provider().name}")
 
 
 def override_provider_per_call(sess: Session) -> None:
@@ -64,9 +69,11 @@ def override_provider_per_call(sess: Session) -> None:
 
 def provider_introspection(sess: Session) -> None:
     """Inspect and detach providers attached to a session."""
-    sess.has_provider("OpenAI")
-    sess.current_provider()
+    print(f"has OpenAI:     {sess.has_provider('OpenAI')}")
+    print(f"has OpenRouter: {sess.has_provider('OpenRouter')}")
+    print(f"current:        {sess.current_provider().name}")
     sess.detach_provider("OpenRouter")
+    print(f"after detach, has OpenRouter: {sess.has_provider('OpenRouter')}")
 
 
 if __name__ == "__main__":

--- a/examples/session/session_providers.py
+++ b/examples/session/session_providers.py
@@ -12,9 +12,7 @@ from daft import Session
 from daft.ai.openai.provider import OpenAIProvider
 from daft.functions import prompt
 
-QUESTIONS = daft.from_pydict(
-    {"question": ["What is the capital of France?", "What is 2 + 2?"]}
-)
+QUESTIONS = daft.from_pydict({"question": ["What is the capital of France?", "What is 2 + 2?"]})
 
 
 def global_provider() -> None:
@@ -35,9 +33,7 @@ def custom_endpoint_provider() -> None:
 def named_provider_objects() -> Session:
     """Attach multiple named Provider instances to a session for fine-grained control."""
     sess = Session()
-    sess.attach_provider(
-        OpenAIProvider(name="OpenAI", api_key=os.environ["OPENAI_API_KEY"])
-    )
+    sess.attach_provider(OpenAIProvider(name="OpenAI", api_key=os.environ["OPENAI_API_KEY"]))
     sess.attach_provider(
         OpenAIProvider(
             name="OpenRouter",

--- a/examples/session/session_providers.py
+++ b/examples/session/session_providers.py
@@ -1,0 +1,85 @@
+# /// script
+# description = "Session providers - attach, switch, and use multiple AI providers"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft[openai]>=0.7.8", "python-dotenv"]
+# ///
+import os
+
+from dotenv import load_dotenv
+
+import daft
+from daft import Session
+from daft.ai.openai.provider import OpenAIProvider
+from daft.functions import prompt
+
+QUESTIONS = daft.from_pydict(
+    {"question": ["What is the capital of France?", "What is 2 + 2?"]}
+)
+
+
+def global_provider() -> None:
+    """Simplest setup: load a built-in provider by name and use it as the default."""
+    daft.set_provider("openai", api_key=os.environ["OPENAI_API_KEY"])
+    QUESTIONS.with_column("answer", prompt(daft.col("question"), model="gpt-4o-mini")).show()
+
+
+def custom_endpoint_provider() -> None:
+    """Point at any OpenAI-compatible service (OpenRouter, Gemini, vLLM, Ollama) via base_url."""
+    daft.set_provider(
+        "openai",
+        api_key=os.environ.get("OPENROUTER_API_KEY", ""),
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+
+def named_provider_objects() -> Session:
+    """Attach multiple named Provider instances to a session for fine-grained control."""
+    sess = Session()
+    sess.attach_provider(
+        OpenAIProvider(name="OpenAI", api_key=os.environ["OPENAI_API_KEY"])
+    )
+    sess.attach_provider(
+        OpenAIProvider(
+            name="OpenRouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key=os.environ.get("OPENROUTER_API_KEY", ""),
+        )
+    )
+    return sess
+
+
+def switch_active_provider(sess: Session) -> None:
+    """Switch the session's active provider without detaching or reconfiguring."""
+    sess.set_provider("OpenAI")
+    sess.set_provider("OpenRouter")
+
+
+def override_provider_per_call(sess: Session) -> None:
+    """Override the session default by passing a provider directly to prompt/embed."""
+    QUESTIONS.with_column(
+        "answer",
+        prompt(
+            daft.col("question"),
+            provider=sess.get_provider("OpenAI"),
+            model="gpt-4o-mini",
+        ),
+    ).show()
+
+
+def provider_introspection(sess: Session) -> None:
+    """Inspect and detach providers attached to a session."""
+    sess.has_provider("OpenAI")
+    sess.current_provider()
+    sess.detach_provider("OpenRouter")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    global_provider()
+    custom_endpoint_provider()
+
+    sess = named_provider_objects()
+    switch_active_provider(sess)
+    override_provider_per_call(sess)
+    provider_introspection(sess)

--- a/examples/session/session_sql.py
+++ b/examples/session/session_sql.py
@@ -33,9 +33,7 @@ def build_company_session() -> Session:
 
 def basic_query(sess: Session) -> None:
     """Run a basic SELECT/WHERE/ORDER BY against an attached table."""
-    sess.sql(
-        "SELECT * FROM employees WHERE department = 'Engineering' ORDER BY salary DESC"
-    ).show()
+    sess.sql("SELECT * FROM employees WHERE department = 'Engineering' ORDER BY salary DESC").show()
 
 
 def distinct_query(sess: Session) -> None:

--- a/examples/session/session_sql.py
+++ b/examples/session/session_sql.py
@@ -1,0 +1,82 @@
+# /// script
+# description = "Session SQL - query attached tables with SQL through a session"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+import daft
+from daft import Catalog, Session
+
+
+def build_company_session() -> Session:
+    """Build a session with a company catalog of employees and departments."""
+    catalog = Catalog.from_pydict(
+        {
+            "employees": {
+                "id": [1, 2, 3, 4, 5],
+                "name": ["Alice", "Bob", "Charlie", "Diana", "Eve"],
+                "department": ["Engineering", "Sales", "Engineering", "Sales", "Engineering"],
+                "salary": [120_000, 85_000, 110_000, 90_000, 130_000],
+            },
+            "departments": {
+                "name": ["Engineering", "Sales", "Marketing"],
+                "budget": [500_000, 300_000, 200_000],
+            },
+        },
+        name="company",
+    )
+    sess = Session()
+    sess.attach_catalog(catalog)
+    sess.set_catalog("company")
+    return sess
+
+
+def basic_query(sess: Session) -> None:
+    """Run a basic SELECT/WHERE/ORDER BY against an attached table."""
+    sess.sql(
+        "SELECT * FROM employees WHERE department = 'Engineering' ORDER BY salary DESC"
+    ).show()
+
+
+def distinct_query(sess: Session) -> None:
+    """Use DISTINCT to find unique values in a column."""
+    sess.sql("SELECT DISTINCT department FROM employees").show()
+
+
+def join_query(sess: Session) -> None:
+    """Join two catalog tables with SQL."""
+    sess.sql("""
+        SELECT e.name, e.department, e.salary, d.budget
+        FROM employees e
+        JOIN departments d ON e.department = d.name
+        ORDER BY e.salary DESC
+    """).show()
+
+
+def global_sql(sess: Session) -> None:
+    """Use module-level daft.sql against the active session."""
+    with sess:
+        daft.sql("SELECT name, salary FROM employees WHERE salary > 100000").show()
+
+
+def sql_with_temp_table(sess: Session) -> None:
+    """Join a session-scoped temp table against catalog tables in SQL."""
+    sess.create_temp_table(
+        "bonuses",
+        daft.from_pydict({"employee_id": [1, 3, 5], "bonus": [10_000, 8_000, 15_000]}),
+    )
+    sess.sql("""
+        SELECT e.name, e.salary, b.bonus, (e.salary + b.bonus) AS total_comp
+        FROM employees e
+        JOIN bonuses b ON e.id = b.employee_id
+        ORDER BY total_comp DESC
+    """).show()
+
+
+if __name__ == "__main__":
+    sess = build_company_session()
+    basic_query(sess)
+    distinct_query(sess)
+    join_query(sess)
+    global_sql(sess)
+    sql_with_temp_table(sess)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12, <3.13"
 dependencies = [
     "daft>=0.7.8",
+    "daft-h3",
     "python-dotenv",
 ]
 

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -76,6 +76,15 @@ SCRIPTS: list[Script] = [
     Script("examples/prompt/prompt_structured_outputs.py",  env=["OPENROUTER_API_KEY"]),
     Script("examples/prompt/prompt_unity_catalog.py",       env=["DATABRICKS_TOKEN", "OPENAI_API_KEY"], skip="daft.unity_catalog module not available in daft 0.7.8"),
 
+    # ── examples/session ────────────────────────────────────────────
+    Script("examples/session/session_basics.py"),
+    Script("examples/session/session_catalogs.py"),
+    Script("examples/session/session_context_config.py"),
+    Script("examples/session/session_extension_h3.py"),
+    Script("examples/session/session_namespaces.py"),
+    Script("examples/session/session_providers.py",     env=["OPENAI_API_KEY"]),
+    Script("examples/session/session_sql.py"),
+
     # ── examples/sql ────────────────────────────────────────────────
     Script("examples/sql/stocks.py"),
 

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "daft" },
+    { name = "daft-h3" },
     { name = "python-dotenv" },
 ]
 
@@ -76,6 +77,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "daft", specifier = ">=0.7.8" },
+    { name = "daft-h3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.2.0" },
@@ -85,6 +87,21 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.9.0" },
 ]
 provides-extras = ["test", "lint"]
+
+[[package]]
+name = "daft-h3"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "daft" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/f5/52c7e50a9d800388c24b8743ed7869c560b4b59d298deb622634d3c7e35c/daft_h3-0.1.0.tar.gz", hash = "sha256:1d19f244cf55d4568772a05c119a475538c1adfbee56e84aa681d70c7e92c10f", size = 60510, upload-time = "2026-04-17T17:59:22.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/90/5d07d9ccfe0428dc9b40c018d8c561342bacd474ffe7af5cac0a7bb309de/daft_h3-0.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:291ddbb34c5fb92df4c2fddc64f91832459c6ad6a8faaa94b9ce8a71352124f0", size = 476446, upload-time = "2026-04-17T17:59:08.3Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/0e/c1d83abdad3280790614b931d35269c49c0a6ddd5b4bd55684c7dd94c9e2/daft_h3-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:588e53afcdcc41e14d3808194ad740674d56f188eaa52f0f012eea486b289394", size = 440434, upload-time = "2026-04-17T17:59:10.015Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7c/cd4c34481e135d92b81389821a7e8199fafcde01be016756b8ab029398dc/daft_h3-0.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f3d5920bca716e326f6e60c6c52c2ab082139491c55e3bb2a143507d29be924a", size = 481128, upload-time = "2026-04-17T17:59:11.604Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d9/390c6a1e84588f5a60c6976f7adbba484d5f5adbae906a2014246dd80d7b/daft_h3-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:771c9604bc5a2c040c7611d0a40c466047052c4479882e691043a634766ed548", size = 501242, upload-time = "2026-04-17T17:59:13.499Z" },
+]
 
 [[package]]
 name = "execnet"


### PR DESCRIPTION
## Summary

- Adds `examples/session/` with 7 focused example scripts covering the full Daft session API surface
- Each script uses a clean factory-of-functions style: one function per pattern, docstring explains it, `__main__` calls them in sequence
- All scripts tested green locally; registered in `tests/registry.py`
- Adds `daft-h3` to project dependencies

## Scripts

| File | Patterns demonstrated |
|---|---|
| `session_basics.py` | Explicit session, context manager, global helpers |
| `session_providers.py` | Global, custom-endpoint, named, multi-provider, per-call override |
| `session_catalogs.py` | In-memory catalog, attach, create/temp tables, existence checks, external catalog factories |
| `session_sql.py` | SELECT/WHERE, DISTINCT, JOIN, global `daft.sql()`, temp-table joins |
| `session_namespaces.py` | Create/use/drop namespaces, `Identifier`, pattern-filtered listing |
| `session_context_config.py` | Execution config, planning config, scoped context managers, S3 IO config |
| `session_extension_h3.py` | `load_extension()` with `daft-h3`: lat/lng→cells, hex↔UInt64, inspect, parent rollup, grid distance |

## Test plan
- [x] `session_basics.py` — passes
- [x] `session_catalogs.py` — passes
- [x] `session_namespaces.py` — passes
- [x] `session_sql.py` — passes
- [x] `session_context_config.py` — passes (reads public S3)
- [x] `session_providers.py` — passes (requires `OPENAI_API_KEY`)
- [x] `session_extension_h3.py` — passes (requires `daft-h3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)