### PR TITLE
feat: extract markdown headings example using daft.File

### DIFF
--- a/examples/files/daft_file_markdown.py
+++ b/examples/files/daft_file_markdown.py
@@ -1,0 +1,39 @@
+# /// script
+# description = "Extract markdown headings from files using daft.File"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft>=0.7.8"]
+# ///
+
+from collections.abc import Iterator
+from typing import TypedDict
+
+import daft
+from daft import col
+from daft.functions import unnest
+
+
+class Heading(TypedDict):
+    level: int
+    text: str
+
+
+@daft.func
+def extract_headings(file: daft.File) -> Iterator[Heading]:
+    with file.open() as f:
+        content = f.read().decode("utf-8")
+    for line in content.splitlines():
+        if line.startswith("#"):
+            yield Heading(
+                level=len(line) - len(line.lstrip("#")),
+                text=line.lstrip("# ").strip(),
+            )
+
+
+if __name__ == "__main__":
+    df = (
+        daft.from_files("**/*.md")
+        .with_column("heading", extract_headings(col("file")))
+        .select(col("file"), unnest(col("heading")))
+    )
+
+    df.show(10)

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -56,6 +56,7 @@ SCRIPTS: list[Script] = [
     Script("examples/files/daft_audiofile_udf.py"),
     Script("examples/files/daft_file.py"),
     Script("examples/files/daft_file_code.py"),
+    Script("examples/files/daft_file_markdown.py"),
     Script("examples/files/daft_file_pdf.py"),
     Script("examples/files/daft_videofile.py"),
     Script("examples/files/daft_videofile_stream.py"),


### PR DESCRIPTION
## Summary

- Adds `examples/files/daft_file_markdown.py` — uses `daft.from_files()` + `@daft.func` with `Iterator[TypedDict]` return type to extract headings from markdown files
- Registers the example in `tests/registry.py`

## Test Plan

- [x] `uv run examples/files/daft_file_markdown.py` runs successfully
- [x] `pytest tests/test_examples.py -k file_markdown` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)