### PR TITLE
fix: add missing dependency to video quickstart

### DIFF
--- a/quickstart/05_video_file.py
+++ b/quickstart/05_video_file.py
@@ -13,7 +13,7 @@ Run:
 # /// script
 # description = "Video-oriented patterns using daft.VideoFile and PyAV"
 # requires-python = ">=3.12, <3.13"
-# dependencies = ["daft[video]>=0.7.10"]
+# dependencies = ["daft[video]>=0.7.10", "typing-extensions>=4.0.0"]
 # ///
 
 import daft


### PR DESCRIPTION
Hello maintainers,

I hope you are doing well. I noticed that running the video quickstart with `uv run quickstart/05_video_file.py` currently fails in a fresh isolated script environment because `typing_extensions` is not installed, even though Daft imports it at runtime.

This PR makes a very small change by declaring `typing-extensions` explicitly in the script metadata for `quickstart/05_video_file.py`. After this change, the example runs successfully with `uv`.

## Summary
- Add `typing-extensions` to the video quickstart script dependencies
- Ensure `uv run quickstart/05_video_file.py` works in a clean isolated environment

## Test plan
- Ran `uv run quickstart/05_video_file.py` successfully
- Commit hook ran `uv run ruff check .` successfully
- Commit hook ran `uv run ruff format --check .` successfully

Thank you very much for considering this contribution. I would be grateful if you could review it when convenient, and I would be happy to make any adjustments if needed.