### PR TITLE
Add HDF5 file usage examples

### DIFF
--- a/examples/files/hdf5_func.py
+++ b/examples/files/hdf5_func.py
@@ -1,0 +1,47 @@
+# /// script
+# description = "Read a HDF5 file and return a struct of the requested fields"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft[hdf5]>=0.7.16"]
+# ///
+import os
+
+import h5py
+import numpy as np
+
+import daft
+from daft import col
+from daft.functions import hdf5_attrs, hdf5_file, hdf5_keys, hdf5_metadata
+
+
+def create_hdf5_sample_file(path: str):
+    with h5py.File(path, "w") as f:
+        f.attrs["source"] = "sample_data"
+        grp = f.create_group("subgroup")
+        
+        dist = grp.create_dataset("distance_dataset", data=np.array([1.0, 2.0, 3.0]))
+        dist.attrs["unit"] = "meters"
+
+        ints = grp.create_dataset("int_dataset", data=np.array([1, 2, 3], dtype=np.int32))
+        ints.attrs["unit"] = "count"
+
+
+if __name__ == "__main__":
+    BASE_URI = os.path.dirname(os.path.abspath(__file__))
+    sample_path = os.path.join(BASE_URI, "sample.h5")
+
+    # Create some sample data
+    if not os.path.exists(sample_path):
+        create_hdf5_sample_file(sample_path)
+   
+    # Discover the files
+    df = daft.from_files(sample_path)
+
+    # Process the data
+    df = (
+        df.with_column("h5_file", hdf5_file(col("file")))
+        .with_column("attrs", hdf5_attrs(col("h5_file")))
+        .with_column("keys", hdf5_keys(col("h5_file")))
+        .with_column("metadata", hdf5_metadata(col("h5_file")))
+        .select("h5_file", "attrs", "keys", col("metadata").explode().unnest())
+    )
+    df.show()

--- a/examples/files/hdf5_func.py
+++ b/examples/files/hdf5_func.py
@@ -1,7 +1,11 @@
 # /// script
-# description = "Read a HDF5 file and return a struct of the requested fields"
+# description = "Runnable demo of the egodex facade: raw EgoDex HDF5 -> a queryable hand-pose dataset."
 # requires-python = ">=3.12, <3.13"
-# dependencies = ["daft[hdf5]>=0.7.16"]
+# dependencies = ["daft[hdf5]"]
+#
+# [tool.uv]
+# prerelease = "allow"
+# extra-index-url = ["https://nightly.daft.ai"]
 # ///
 import os
 

--- a/examples/files/hdf5_udf.py
+++ b/examples/files/hdf5_udf.py
@@ -1,7 +1,11 @@
 # /// script
-# description = "Read a HDF5 file and return a struct of the requested fields"
+# description = "Runnable demo of the egodex facade: raw EgoDex HDF5 -> a queryable hand-pose dataset."
 # requires-python = ">=3.12, <3.13"
-# dependencies = ["daft[hdf5]>=0.7.16"]
+# dependencies = ["daft[hdf5]"]
+#
+# [tool.uv]
+# prerelease = "allow"
+# extra-index-url = ["https://nightly.daft.ai"]
 # ///
 import h5py
 

--- a/examples/files/hdf5_udf.py
+++ b/examples/files/hdf5_udf.py
@@ -1,0 +1,38 @@
+# /// script
+# description = "Read a HDF5 file and return a struct of the requested fields"
+# requires-python = ">=3.12, <3.13"
+# dependencies = ["daft[hdf5]>=0.7.16"]
+# ///
+import h5py
+
+import daft
+from daft import DataType, Hdf5File, col
+
+
+# Build the UDF that will read the trajectory data and return a struct of the requested fields
+@daft.func(
+    return_dtype=DataType.struct({
+        "action/gripper_position": DataType.tensor(DataType.float64()),
+        "action/target_gripper_position": DataType.tensor(DataType.float64()),
+        "observation/robot_state/gripper_position": DataType.tensor(DataType.float64()),
+    }),
+    use_process=False,
+    unnest=True,
+)
+def read_droid_trajectory(file: Hdf5File):
+    with file.to_tempfile() as tmp, h5py.File(tmp.name, "r") as h5:
+        return {
+            "action/gripper_position": h5["action/gripper_position"][()],
+            "action/target_gripper_position": h5["action/target_gripper_position"][()],
+            "observation/robot_state/gripper_position": h5["observation/robot_state/gripper_position"][()],
+        }
+
+if __name__ == "__main__":
+
+    df = (
+        daft.datasets.droid.raw()
+        .where(col("success")) # filter out failed episodes
+        .select(col("current_task"), read_droid_trajectory(col("trajectory")))
+    )
+
+    df.show(3) 


### PR DESCRIPTION
## Summary
- Adds `hdf5_func.py`: demonstrates Daft's built-in HDF5 functions (`hdf5_file`, `hdf5_attrs`, `hdf5_keys`, `hdf5_metadata`) on a locally-created sample file
- Adds `hdf5_udf.py`: demonstrates a custom UDF that reads DROID robotics trajectory data from HDF5 files using `Hdf5File` and `to_tempfile()`

## Test plan
- [ ] Run `hdf5_func.py` with `uv run` to verify sample file creation and built-in function output
- [ ] Run `hdf5_udf.py` with `uv run` to verify DROID dataset UDF extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)