### PR TITLE
EgoDex: nbstripout hook to keep example notebooks output-free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: setup setup-egodex test test-quickstart test-examples test-no-creds lint format precommit install-hooks
+.PHONY: setup setup-egodex test test-quickstart test-examples test-no-creds lint format precommit install-hooks strip-notebooks
+
+# Example notebooks are committed source-only (no baked-in run outputs). Scoped
+# to datasets/ so conference/demo notebooks under notebooks/ keep their outputs.
+DATASET_NOTEBOOKS := $(shell find datasets -name '*.ipynb' -not -path '*/.ipynb_checkpoints/*')
 
 setup: install-hooks
 	uv sync --extra test --extra lint
@@ -22,8 +26,12 @@ format:
 	uv run --extra lint ruff format .
 	uv run --extra lint ruff check --fix .
 
+strip-notebooks:
+	uv run --extra lint nbstripout $(DATASET_NOTEBOOKS)
+
 precommit: lint
 	uv run --extra lint ruff format --check .
+	uv run --extra lint nbstripout --verify $(DATASET_NOTEBOOKS)
 	@echo "All checks passed."
 
 # ── Tests ──────────────────────────────────────────────────────────────

--- a/datasets/egodex/egodex_demo.ipynb
+++ b/datasets/egodex/egodex_demo.ipynb
@@ -1,480 +1,480 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "30be8aa3",
-      "metadata": {},
-      "source": [
-        "# EgoDex Scenario Search on Daft\n",
-        "\n",
-        "This notebook reproduces the workflow behind the EgoDex scenario-search blog post with the cleaned `egodex` package. It reads raw EgoDex HDF5 episodes directly, computes hand-pose feature tracks, embeds sampled video frames with SigLIP-2 through Daft, then runs pose-only, text-only, and combined pose plus semantic queries.\n",
-        "\n",
-        "Point `DATA_ROOT` at the extracted ~16 GB EgoDex download and use `EPISODE_LIMIT` to bound how many episodes each run processes."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "79d7beae",
-      "metadata": {},
-      "source": [
-        "## 0. Setup\n",
-        "\n",
-        "From the repository root, install the editable package and notebook kernel once:\n",
-        "\n",
-        "```bash\n",
-        "uv sync --extra egodex --extra notebook\n",
-        "```\n",
-        "\n",
-        "Select the repo `.venv` as the Jupyter kernel. The notebook resolves paths from the repo root automatically, so the kernel cwd can be anywhere under the checkout."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "38e67cd7",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "\n",
-        "\n",
-        "def find_repo_root(start: Path) -> Path:\n",
-        "    for candidate in (start, *start.parents):\n",
-        "        if (candidate / \"pyproject.toml\").exists() and (candidate / \"datasets\" / \"egodex\").exists():\n",
-        "            return candidate\n",
-        "    raise RuntimeError(\"Could not find the daft-examples repository root.\")\n",
-        "\n",
-        "\n",
-        "def resolve_data_root(repo_root: Path) -> Path:\n",
-        "    candidates = (\n",
-        "        repo_root / \"datasets\" / \"egodex\" / \".data\",\n",
-        "        repo_root / \".data\",\n",
-        "        Path(\".data\"),\n",
-        "    )\n",
-        "    for path in candidates:\n",
-        "        if path.exists() and any(path.glob(\"**/*.hdf5\")):\n",
-        "            return path.resolve()\n",
-        "    raise FileNotFoundError(\n",
-        "        \"EgoDex HDF5 episodes not found. Extract the dataset to \"\n",
-        "        f\"{repo_root / 'datasets' / 'egodex' / '.data'} before running this notebook.\"\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "REPO_ROOT = find_repo_root(Path.cwd().resolve())\n",
-        "DATA_ROOT = resolve_data_root(REPO_ROOT)\n",
-        "FEATURES_DIR = REPO_ROOT / \"datasets\" / \"egodex\" / \".features\"\n",
-        "EMBEDDINGS_DIR = REPO_ROOT / \"datasets\" / \"egodex\" / \".embeddings\"\n",
-        "\n",
-        "print(f\"repo root: {REPO_ROOT}\")\n",
-        "print(f\"data root: {DATA_ROOT}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f1457965",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Quiet Daft and HuggingFace progress bars before any pipeline work.\n",
-        "os.environ.setdefault(\"DAFT_PROGRESS_BAR\", \"0\")\n",
-        "os.environ.setdefault(\"DAFT_STA\", \"error\")\n",
-        "os.environ.setdefault(\"HF_HUB_DISABLE_PROGRESS_BARS\", \"1\")\n",
-        "os.environ.setdefault(\"TRANSFORMERS_VERBOSITY\", \"error\")\n",
-        "\n",
-        "import daft\n",
-        "from egodex import (\n",
-        "    FPS,\n",
-        "    SCENARIOS,\n",
-        "    EgoDexPipeline,\n",
-        "    calibrate,\n",
-        "    overlay,\n",
-        "    pose_search_many,\n",
-        "    query,\n",
-        ")\n",
-        "\n",
-        "EPISODE_LIMIT = 10\n",
-        "PREVIEW_SECONDS = 5.0\n",
-        "TOP_K = 3\n",
-        "\n",
-        "# See how EgoDexPipeline is implemented in pipeline.py\n",
-        "pipeline = EgoDexPipeline(\n",
-        "    str(DATA_ROOT),\n",
-        "    features_dir=str(FEATURES_DIR),\n",
-        "    embeddings_dir=str(EMBEDDINGS_DIR),\n",
-        ")\n",
-        "\n",
-        "print(f\"Daft {daft.__version__}\")\n",
-        "print(f\"episode limit: {EPISODE_LIMIT}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "52419952",
-      "metadata": {},
-      "source": [
-        "## 1. Direct HDF5 Episode Read\n",
-        "\n",
-        "`raw()` discovers every `<task>/<episode>.hdf5` file under `DATA_ROOT` and attaches the sibling MP4 as a lazy video file. `EPISODE_LIMIT` trims the episode table before any metadata or trajectory tensors are read."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fdaeed5f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "episodes = pipeline.raw()\n",
-        "if EPISODE_LIMIT is not None:\n",
-        "    episodes = episodes.limit(int(EPISODE_LIMIT))\n",
-        "\n",
-        "episodes.select(\"task\", \"episode_id\", \"video\").show(10)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "667cc027",
-      "metadata": {},
-      "source": [
-        "## 2. Pose Feature Branch\n",
-        "\n",
-        "The pose branch stores **one row per frame**. `trajectory()` reads only the transform tensors needed for pose features, and the feature stage runs in two steps:\n",
-        "\n",
-        "1. `frame_features()` — an episode-level UDF computes the instantaneous hand geometry (closure, grip distances, wrist position, ...) and explodes it into per-frame rows keyed by `(task, episode_id, frame_index)`.\n",
-        "2. `temporal_features()` — every action rate (grasping, lifting, reaching, twisting, ...) is a **Daft window expression** over `Window().partition_by(\"task\", \"episode_id\").order_by(\"frame_index\")`: next-frame diffs via `lead(1)`, point speeds via `euclidean_distance`, and smoothing via a centered `rows_between(-2, 2)` mean. The one custom UDF, `forearm_roll`, is fed by the same window — this frame's wrist rotation plus the next frame's via `lead(1)`.\n",
-        "\n",
-        "Because the rates are expressions, the temporal math stays in the query plan — no collect, and the same code applies to any per-frame table with these columns (e.g. LeRobot-style parquet). Query-time scenarios group the frames back into per-episode tracks and stitch matching frames into segments.\n",
-        "\n",
-        "`calculate_features()` runs both steps at once."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4e296586",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Read the raw trajectories, then build features in two stages:\n",
-        "# per-frame spatial geometry, plus action rates as Daft window expressions.\n",
-        "trajectories = pipeline.trajectory(episodes)\n",
-        "spatial = pipeline.frame_features(trajectories)\n",
-        "features = pipeline.temporal_features(spatial)  # see temporal.py for the window expressions\n",
-        "\n",
-        "# One row per frame; rates like wrist_vert_vel/roll come from lead(1) windows.\n",
-        "features.select(\"task\", \"episode_id\", \"frame_index\", \"closure_L\", \"wrist_vert_vel_L\", \"roll_L\").show(10)\n",
-        "features.write_parquet(str(FEATURES_DIR))\n",
-        "print(f\"wrote features to {FEATURES_DIR}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b3add49f",
-      "metadata": {},
-      "source": [
-        "## 3. Scenario Vocabulary\n",
-        "\n",
-        "The blog separates physical states from actions. States read a frame's hand shape; actions read motion between frames. Thresholds are calibrated from continuous feature tracks and reused across queries."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b2d969e3",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "SCENARIO_CATALOG = [\n",
-        "    {\"scenario\": \"openness\", \"kind\": \"state\", \"signal\": \"closure band\"},\n",
-        "    {\"scenario\": \"writing_grip\", \"kind\": \"state\", \"signal\": \"tripod grip geometry\"},\n",
-        "    {\"scenario\": \"hammer_grip\", \"kind\": \"state\", \"signal\": \"power grip geometry\"},\n",
-        "    {\"scenario\": \"twisting\", \"kind\": \"action\", \"signal\": \"forearm roll rate\"},\n",
-        "    {\"scenario\": \"reaching\", \"kind\": \"action\", \"signal\": \"arm extension rate\"},\n",
-        "    {\"scenario\": \"lifting\", \"kind\": \"action\", \"signal\": \"wrist vertical velocity\"},\n",
-        "    {\"scenario\": \"grasping\", \"kind\": \"action\", \"signal\": \"curl closing rate\"},\n",
-        "    {\"scenario\": \"in_hand\", \"kind\": \"action\", \"signal\": \"still wrist plus finger articulation\"},\n",
-        "]\n",
-        "\n",
-        "assert set(item[\"scenario\"] for item in SCENARIO_CATALOG) <= set(SCENARIOS)\n",
-        "daft.from_pylist(SCENARIO_CATALOG).show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "004dc4a7",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "thresholds = calibrate(features)\n",
-        "daft.from_pylist([{key: round(value, 4) for key, value in thresholds.items()}])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a0ef3321",
-      "metadata": {},
-      "source": [
-        "## 4. Pose-Only Search\n",
-        "\n",
-        "Pose-only queries rank episodes by matching frame count inside Daft. Each scenario is a lazy plan: the match UDF scans episode tracks, then Daft sorts and limits the top hits."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7c679aed",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "POSE_QUERIES = [\n",
-        "    (\"open hands\", {\"pose\": \"openness\", \"open_lo\": 0.65, \"open_hi\": 1.0}),\n",
-        "    (\"closed hands\", {\"pose\": \"openness\", \"open_lo\": 0.0, \"open_hi\": 0.35}),\n",
-        "    (\"writing grip\", {\"pose\": \"writing_grip\"}),\n",
-        "    (\"hammer grip\", {\"pose\": \"hammer_grip\"}),\n",
-        "    (\"twisting\", {\"pose\": \"twisting\"}),\n",
-        "    (\"reaching\", {\"pose\": \"reaching\"}),\n",
-        "    (\"lifting\", {\"pose\": \"lifting\"}),\n",
-        "    (\"grasping\", {\"pose\": \"grasping\"}),\n",
-        "    (\"in-hand manipulation\", {\"pose\": \"in_hand\"}),\n",
-        "]\n",
-        "\n",
-        "pose_hits = pose_search_many(features, POSE_QUERIES, k=TOP_K, thresholds=thresholds)\n",
-        "pose_hits.select(\"query\", \"task\", \"episode_id\", \"score\", \"segments\").show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0dd35858",
-      "metadata": {},
-      "source": [
-        "## 5. Video Frame Sampling\n",
-        "\n",
-        "The semantic branch samples video frames at about 1 fps. This preview decodes only the first few seconds so the cell stays bounded."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e59abdf5",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "preview_frames = pipeline.camera_frames(\n",
-        "    episodes,\n",
-        "    end_time=PREVIEW_SECONDS,\n",
-        "    sample_interval_seconds=1.0,\n",
-        ")\n",
-        "preview_frames.select(\"task\", \"episode_id\", \"video_frames\").explode(\"video_frames\").select(\n",
-        "    \"task\",\n",
-        "    \"episode_id\",\n",
-        "    daft.col(\"video_frames\")[\"frame_index\"].alias(\"frame_index\"),\n",
-        "    daft.col(\"video_frames\")[\"frame_time\"].alias(\"frame_time\"),\n",
-        ").show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "38cfb6be",
-      "metadata": {},
-      "source": [
-        "## 6. SigLIP Embeddings\n",
-        "\n",
-        "Embed sampled frames with SigLIP-2 through a batch UDF. The first run downloads and loads model weights."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ca86ad05",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "embedding_frames = pipeline.camera_frames(\n",
-        "    episodes,\n",
-        "    sample_interval_seconds=pipeline.sample_interval_seconds,\n",
-        ")\n",
-        "embeddings = pipeline.embed_frames(embedding_frames)\n",
-        "embeddings.select(\"task\", \"episode_id\", \"frame_index\", \"timestamp\", \"clip_emb\").show(3)\n",
-        "embeddings.write_parquet(str(EMBEDDINGS_DIR))\n",
-        "print(f\"wrote embeddings to {EMBEDDINGS_DIR}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9d4ba416",
-      "metadata": {},
-      "source": [
-        "## 7. Text and Combined Search\n",
-        "\n",
-        "Text-only search ranks sampled frame embeddings by SigLIP similarity and returns a short window around the best frame. Combined search first applies the pose mask, then ranks matching sampled frames by text similarity."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "493b0720",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "TEXT_QUERIES = [\n",
-        "    (\"text: chopsticks\", {\"text\": \"chopsticks\"}),\n",
-        "    (\"text: stapler\", {\"text\": \"stapler\"}),\n",
-        "    (\"hammer grip + stapler\", {\"pose\": \"hammer_grip\", \"text\": \"stapler\"}),\n",
-        "    (\"grasping + shirt\", {\"pose\": \"grasping\", \"text\": \"shirt\"}),\n",
-        "    (\"reaching + marbles\", {\"pose\": \"reaching\", \"text\": \"marbles\"}),\n",
-        "]\n",
-        "\n",
-        "text_rows = []\n",
-        "for label, params in TEXT_QUERIES:\n",
-        "    for hit in query(features, clip=embeddings, k=TOP_K, thresholds=thresholds, **params):\n",
-        "        text_rows.append(\n",
-        "            {\n",
-        "                \"query\": label,\n",
-        "                **{key: value for key, value in hit.items() if key != \"segments\"},\n",
-        "                \"segments\": [[int(start), int(end)] for start, end in hit[\"segments\"]],\n",
-        "            }\n",
-        "        )\n",
-        "\n",
-        "text_hits = daft.from_pylist(text_rows)\n",
-        "text_hits.select(\"query\", \"task\", \"episode_id\", \"score\", \"segments\").show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e3d03d4c",
-      "metadata": {},
-      "source": [
-        "## 8. Segment Inspection\n",
-        "\n",
-        "Use the returned segments to inspect exact frames. This mirrors the blog's dashboard behavior in notebook form: pick a hit, list its segments, then overlay the HDF5 skeleton on frames from the first segment."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "68ec2032",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "def _segment_bounds(segment):\n",
-        "    if isinstance(segment, dict):\n",
-        "        return int(segment[\"_0\"]), int(segment[\"_1\"])\n",
-        "    return int(segment[0]), int(segment[1])\n",
-        "\n",
-        "\n",
-        "def first_hit(hits_df):\n",
-        "    if \"query\" not in hits_df.column_names:\n",
-        "        return None, None\n",
-        "    row = hits_df.sort(\"score\", desc=True).limit(1).to_pydict()\n",
-        "    if not row[\"query\"] or row[\"query\"][0] is None:\n",
-        "        return None, None\n",
-        "    return row[\"query\"][0], {\n",
-        "        \"task\": row[\"task\"][0],\n",
-        "        \"episode_id\": int(row[\"episode_id\"][0]),\n",
-        "        \"score\": float(row[\"score\"][0]),\n",
-        "        \"segments\": [_segment_bounds(segment) for segment in row[\"segments\"][0]],\n",
-        "    }\n",
-        "\n",
-        "\n",
-        "def first_available_hit(*hit_tables):\n",
-        "    for hits_df in hit_tables:\n",
-        "        label, hit = first_hit(hits_df)\n",
-        "        if hit is not None:\n",
-        "            return label, hit\n",
-        "    return None, None\n",
-        "\n",
-        "\n",
-        "selected_label, selected_hit = first_available_hit(text_hits, pose_hits)\n",
-        "selected_label, selected_hit"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9cf67458",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if selected_hit is None:\n",
-        "    segment_table = []\n",
-        "else:\n",
-        "    segment_table = [\n",
-        "        {\n",
-        "            \"segment\": index,\n",
-        "            \"start_frame\": start,\n",
-        "            \"end_frame\": end,\n",
-        "            \"start_seconds\": round(start / FPS, 3),\n",
-        "            \"end_seconds\": round(end / FPS, 3),\n",
-        "            \"duration_seconds\": round((end - start + 1) / FPS, 3),\n",
-        "        }\n",
-        "        for index, (start, end) in enumerate(selected_hit[\"segments\"], start=1)\n",
-        "    ]\n",
-        "segment_table"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "52b042c9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from IPython.display import display\n",
-        "\n",
-        "if selected_hit is not None and selected_hit[\"segments\"]:\n",
-        "    start, end = selected_hit[\"segments\"][0]\n",
-        "    midpoint = (start + end) // 2\n",
-        "    frame_indices = sorted({start, midpoint, end})\n",
-        "    print(f\"{selected_label}: {selected_hit['task']}/{selected_hit['episode_id']} segment {start}-{end}\")\n",
-        "    for frame_index in frame_indices:\n",
-        "        print(f\"frame {frame_index}\")\n",
-        "        display(\n",
-        "            overlay(\n",
-        "                DATA_ROOT,\n",
-        "                selected_hit[\"task\"],\n",
-        "                selected_hit[\"episode_id\"],\n",
-        "                frame_index,\n",
-        "                radius=3,\n",
-        "            )\n",
-        "        )\n",
-        "else:\n",
-        "    print(\"No segment available to visualize.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a59b5b3d",
-      "metadata": {},
-      "source": [
-        "## 9. Scaling Up\n",
-        "\n",
-        "Increase `EPISODE_LIMIT` for broader search, or set it to `None` to process every episode under `DATA_ROOT`. Feature and embedding parquets land in `FEATURES_DIR` and `EMBEDDINGS_DIR` so you can reload them in a later session with `daft.read_parquet(...)` instead of recomputing."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.12"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# EgoDex Scenario Search on Daft\n",
+    "\n",
+    "This notebook reproduces the workflow behind the EgoDex scenario-search blog post with the cleaned `egodex` package. It reads raw EgoDex HDF5 episodes directly, computes hand-pose feature tracks, embeds sampled video frames with SigLIP-2 through Daft, then runs pose-only, text-only, and combined pose plus semantic queries.\n",
+    "\n",
+    "Point `DATA_ROOT` at the extracted ~16 GB EgoDex download and use `EPISODE_LIMIT` to bound how many episodes each run processes."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## 0. Setup\n",
+    "\n",
+    "From the repository root, install the editable package and notebook kernel once:\n",
+    "\n",
+    "```bash\n",
+    "uv sync --extra egodex --extra notebook\n",
+    "```\n",
+    "\n",
+    "Select the repo `.venv` as the Jupyter kernel. The notebook resolves paths from the repo root automatically, so the kernel cwd can be anywhere under the checkout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def find_repo_root(start: Path) -> Path:\n",
+    "    for candidate in (start, *start.parents):\n",
+    "        if (candidate / \"pyproject.toml\").exists() and (candidate / \"datasets\" / \"egodex\").exists():\n",
+    "            return candidate\n",
+    "    raise RuntimeError(\"Could not find the daft-examples repository root.\")\n",
+    "\n",
+    "\n",
+    "def resolve_data_root(repo_root: Path) -> Path:\n",
+    "    candidates = (\n",
+    "        repo_root / \"datasets\" / \"egodex\" / \".data\",\n",
+    "        repo_root / \".data\",\n",
+    "        Path(\".data\"),\n",
+    "    )\n",
+    "    for path in candidates:\n",
+    "        if path.exists() and any(path.glob(\"**/*.hdf5\")):\n",
+    "            return path.resolve()\n",
+    "    raise FileNotFoundError(\n",
+    "        \"EgoDex HDF5 episodes not found. Extract the dataset to \"\n",
+    "        f\"{repo_root / 'datasets' / 'egodex' / '.data'} before running this notebook.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "REPO_ROOT = find_repo_root(Path.cwd().resolve())\n",
+    "DATA_ROOT = resolve_data_root(REPO_ROOT)\n",
+    "FEATURES_DIR = REPO_ROOT / \"datasets\" / \"egodex\" / \".features\"\n",
+    "EMBEDDINGS_DIR = REPO_ROOT / \"datasets\" / \"egodex\" / \".embeddings\"\n",
+    "\n",
+    "print(f\"repo root: {REPO_ROOT}\")\n",
+    "print(f\"data root: {DATA_ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Quiet Daft and HuggingFace progress bars before any pipeline work.\n",
+    "os.environ.setdefault(\"DAFT_PROGRESS_BAR\", \"0\")\n",
+    "os.environ.setdefault(\"DAFT_STA\", \"error\")\n",
+    "os.environ.setdefault(\"HF_HUB_DISABLE_PROGRESS_BARS\", \"1\")\n",
+    "os.environ.setdefault(\"TRANSFORMERS_VERBOSITY\", \"error\")\n",
+    "\n",
+    "import daft\n",
+    "from egodex import (\n",
+    "    FPS,\n",
+    "    SCENARIOS,\n",
+    "    EgoDexPipeline,\n",
+    "    calibrate,\n",
+    "    overlay,\n",
+    "    pose_search_many,\n",
+    "    query,\n",
+    ")\n",
+    "\n",
+    "EPISODE_LIMIT = 10\n",
+    "PREVIEW_SECONDS = 5.0\n",
+    "TOP_K = 3\n",
+    "\n",
+    "# See how EgoDexPipeline is implemented in pipeline.py\n",
+    "pipeline = EgoDexPipeline(\n",
+    "    str(DATA_ROOT),\n",
+    "    features_dir=str(FEATURES_DIR),\n",
+    "    embeddings_dir=str(EMBEDDINGS_DIR),\n",
+    ")\n",
+    "\n",
+    "print(f\"Daft {daft.__version__}\")\n",
+    "print(f\"episode limit: {EPISODE_LIMIT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## 1. Direct HDF5 Episode Read\n",
+    "\n",
+    "`raw()` discovers every `<task>/<episode>.hdf5` file under `DATA_ROOT` and attaches the sibling MP4 as a lazy video file. `EPISODE_LIMIT` trims the episode table before any metadata or trajectory tensors are read."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "episodes = pipeline.raw()\n",
+    "if EPISODE_LIMIT is not None:\n",
+    "    episodes = episodes.limit(int(EPISODE_LIMIT))\n",
+    "\n",
+    "episodes.select(\"task\", \"episode_id\", \"video\").show(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## 2. Pose Feature Branch\n",
+    "\n",
+    "The pose branch stores **one row per frame**. `trajectory()` reads only the transform tensors needed for pose features, and the feature stage runs in two steps:\n",
+    "\n",
+    "1. `frame_features()` — an episode-level UDF computes the instantaneous hand geometry (closure, grip distances, wrist position, ...) and explodes it into per-frame rows keyed by `(task, episode_id, frame_index)`.\n",
+    "2. `temporal_features()` — every action rate (grasping, lifting, reaching, twisting, ...) is a **Daft window expression** over `Window().partition_by(\"task\", \"episode_id\").order_by(\"frame_index\")`: next-frame diffs via `lead(1)`, point speeds via `euclidean_distance`, and smoothing via a centered `rows_between(-2, 2)` mean. The one custom UDF, `forearm_roll`, is fed by the same window — this frame's wrist rotation plus the next frame's via `lead(1)`.\n",
+    "\n",
+    "Because the rates are expressions, the temporal math stays in the query plan — no collect, and the same code applies to any per-frame table with these columns (e.g. LeRobot-style parquet). Query-time scenarios group the frames back into per-episode tracks and stitch matching frames into segments.\n",
+    "\n",
+    "`calculate_features()` runs both steps at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the raw trajectories, then build features in two stages:\n",
+    "# per-frame spatial geometry, plus action rates as Daft window expressions.\n",
+    "trajectories = pipeline.trajectory(episodes)\n",
+    "spatial = pipeline.frame_features(trajectories)\n",
+    "features = pipeline.temporal_features(spatial)  # see temporal.py for the window expressions\n",
+    "\n",
+    "# One row per frame; rates like wrist_vert_vel/roll come from lead(1) windows.\n",
+    "features.select(\"task\", \"episode_id\", \"frame_index\", \"closure_L\", \"wrist_vert_vel_L\", \"roll_L\").show(10)\n",
+    "features.write_parquet(str(FEATURES_DIR))\n",
+    "print(f\"wrote features to {FEATURES_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## 3. Scenario Vocabulary\n",
+    "\n",
+    "The blog separates physical states from actions. States read a frame's hand shape; actions read motion between frames. Thresholds are calibrated from continuous feature tracks and reused across queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SCENARIO_CATALOG = [\n",
+    "    {\"scenario\": \"openness\", \"kind\": \"state\", \"signal\": \"closure band\"},\n",
+    "    {\"scenario\": \"writing_grip\", \"kind\": \"state\", \"signal\": \"tripod grip geometry\"},\n",
+    "    {\"scenario\": \"hammer_grip\", \"kind\": \"state\", \"signal\": \"power grip geometry\"},\n",
+    "    {\"scenario\": \"twisting\", \"kind\": \"action\", \"signal\": \"forearm roll rate\"},\n",
+    "    {\"scenario\": \"reaching\", \"kind\": \"action\", \"signal\": \"arm extension rate\"},\n",
+    "    {\"scenario\": \"lifting\", \"kind\": \"action\", \"signal\": \"wrist vertical velocity\"},\n",
+    "    {\"scenario\": \"grasping\", \"kind\": \"action\", \"signal\": \"curl closing rate\"},\n",
+    "    {\"scenario\": \"in_hand\", \"kind\": \"action\", \"signal\": \"still wrist plus finger articulation\"},\n",
+    "]\n",
+    "\n",
+    "assert set(item[\"scenario\"] for item in SCENARIO_CATALOG) <= set(SCENARIOS)\n",
+    "daft.from_pylist(SCENARIO_CATALOG).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thresholds = calibrate(features)\n",
+    "daft.from_pylist([{key: round(value, 4) for key, value in thresholds.items()}])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## 4. Pose-Only Search\n",
+    "\n",
+    "Pose-only queries rank episodes by matching frame count inside Daft. Each scenario is a lazy plan: the match UDF scans episode tracks, then Daft sorts and limits the top hits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "POSE_QUERIES = [\n",
+    "    (\"open hands\", {\"pose\": \"openness\", \"open_lo\": 0.65, \"open_hi\": 1.0}),\n",
+    "    (\"closed hands\", {\"pose\": \"openness\", \"open_lo\": 0.0, \"open_hi\": 0.35}),\n",
+    "    (\"writing grip\", {\"pose\": \"writing_grip\"}),\n",
+    "    (\"hammer grip\", {\"pose\": \"hammer_grip\"}),\n",
+    "    (\"twisting\", {\"pose\": \"twisting\"}),\n",
+    "    (\"reaching\", {\"pose\": \"reaching\"}),\n",
+    "    (\"lifting\", {\"pose\": \"lifting\"}),\n",
+    "    (\"grasping\", {\"pose\": \"grasping\"}),\n",
+    "    (\"in-hand manipulation\", {\"pose\": \"in_hand\"}),\n",
+    "]\n",
+    "\n",
+    "pose_hits = pose_search_many(features, POSE_QUERIES, k=TOP_K, thresholds=thresholds)\n",
+    "pose_hits.select(\"query\", \"task\", \"episode_id\", \"score\", \"segments\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## 5. Video Frame Sampling\n",
+    "\n",
+    "The semantic branch samples video frames at about 1 fps. This preview decodes only the first few seconds so the cell stays bounded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview_frames = pipeline.camera_frames(\n",
+    "    episodes,\n",
+    "    end_time=PREVIEW_SECONDS,\n",
+    "    sample_interval_seconds=1.0,\n",
+    ")\n",
+    "preview_frames.select(\"task\", \"episode_id\", \"video_frames\").explode(\"video_frames\").select(\n",
+    "    \"task\",\n",
+    "    \"episode_id\",\n",
+    "    daft.col(\"video_frames\")[\"frame_index\"].alias(\"frame_index\"),\n",
+    "    daft.col(\"video_frames\")[\"frame_time\"].alias(\"frame_time\"),\n",
+    ").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## 6. SigLIP Embeddings\n",
+    "\n",
+    "Embed sampled frames with SigLIP-2 through a batch UDF. The first run downloads and loads model weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embedding_frames = pipeline.camera_frames(\n",
+    "    episodes,\n",
+    "    sample_interval_seconds=pipeline.sample_interval_seconds,\n",
+    ")\n",
+    "embeddings = pipeline.embed_frames(embedding_frames)\n",
+    "embeddings.select(\"task\", \"episode_id\", \"frame_index\", \"timestamp\", \"clip_emb\").show(3)\n",
+    "embeddings.write_parquet(str(EMBEDDINGS_DIR))\n",
+    "print(f\"wrote embeddings to {EMBEDDINGS_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## 7. Text and Combined Search\n",
+    "\n",
+    "Text-only search ranks sampled frame embeddings by SigLIP similarity and returns a short window around the best frame. Combined search first applies the pose mask, then ranks matching sampled frames by text similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEXT_QUERIES = [\n",
+    "    (\"text: chopsticks\", {\"text\": \"chopsticks\"}),\n",
+    "    (\"text: stapler\", {\"text\": \"stapler\"}),\n",
+    "    (\"hammer grip + stapler\", {\"pose\": \"hammer_grip\", \"text\": \"stapler\"}),\n",
+    "    (\"grasping + shirt\", {\"pose\": \"grasping\", \"text\": \"shirt\"}),\n",
+    "    (\"reaching + marbles\", {\"pose\": \"reaching\", \"text\": \"marbles\"}),\n",
+    "]\n",
+    "\n",
+    "text_rows = []\n",
+    "for label, params in TEXT_QUERIES:\n",
+    "    for hit in query(features, clip=embeddings, k=TOP_K, thresholds=thresholds, **params):\n",
+    "        text_rows.append(\n",
+    "            {\n",
+    "                \"query\": label,\n",
+    "                **{key: value for key, value in hit.items() if key != \"segments\"},\n",
+    "                \"segments\": [[int(start), int(end)] for start, end in hit[\"segments\"]],\n",
+    "            }\n",
+    "        )\n",
+    "\n",
+    "text_hits = daft.from_pylist(text_rows)\n",
+    "text_hits.select(\"query\", \"task\", \"episode_id\", \"score\", \"segments\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## 8. Segment Inspection\n",
+    "\n",
+    "Use the returned segments to inspect exact frames. This mirrors the blog's dashboard behavior in notebook form: pick a hit, list its segments, then overlay the HDF5 skeleton on frames from the first segment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _segment_bounds(segment):\n",
+    "    if isinstance(segment, dict):\n",
+    "        return int(segment[\"_0\"]), int(segment[\"_1\"])\n",
+    "    return int(segment[0]), int(segment[1])\n",
+    "\n",
+    "\n",
+    "def first_hit(hits_df):\n",
+    "    if \"query\" not in hits_df.column_names:\n",
+    "        return None, None\n",
+    "    row = hits_df.sort(\"score\", desc=True).limit(1).to_pydict()\n",
+    "    if not row[\"query\"] or row[\"query\"][0] is None:\n",
+    "        return None, None\n",
+    "    return row[\"query\"][0], {\n",
+    "        \"task\": row[\"task\"][0],\n",
+    "        \"episode_id\": int(row[\"episode_id\"][0]),\n",
+    "        \"score\": float(row[\"score\"][0]),\n",
+    "        \"segments\": [_segment_bounds(segment) for segment in row[\"segments\"][0]],\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def first_available_hit(*hit_tables):\n",
+    "    for hits_df in hit_tables:\n",
+    "        label, hit = first_hit(hits_df)\n",
+    "        if hit is not None:\n",
+    "            return label, hit\n",
+    "    return None, None\n",
+    "\n",
+    "\n",
+    "selected_label, selected_hit = first_available_hit(text_hits, pose_hits)\n",
+    "selected_label, selected_hit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if selected_hit is None:\n",
+    "    segment_table = []\n",
+    "else:\n",
+    "    segment_table = [\n",
+    "        {\n",
+    "            \"segment\": index,\n",
+    "            \"start_frame\": start,\n",
+    "            \"end_frame\": end,\n",
+    "            \"start_seconds\": round(start / FPS, 3),\n",
+    "            \"end_seconds\": round(end / FPS, 3),\n",
+    "            \"duration_seconds\": round((end - start + 1) / FPS, 3),\n",
+    "        }\n",
+    "        for index, (start, end) in enumerate(selected_hit[\"segments\"], start=1)\n",
+    "    ]\n",
+    "segment_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display\n",
+    "\n",
+    "if selected_hit is not None and selected_hit[\"segments\"]:\n",
+    "    start, end = selected_hit[\"segments\"][0]\n",
+    "    midpoint = (start + end) // 2\n",
+    "    frame_indices = sorted({start, midpoint, end})\n",
+    "    print(f\"{selected_label}: {selected_hit['task']}/{selected_hit['episode_id']} segment {start}-{end}\")\n",
+    "    for frame_index in frame_indices:\n",
+    "        print(f\"frame {frame_index}\")\n",
+    "        display(\n",
+    "            overlay(\n",
+    "                DATA_ROOT,\n",
+    "                selected_hit[\"task\"],\n",
+    "                selected_hit[\"episode_id\"],\n",
+    "                frame_index,\n",
+    "                radius=3,\n",
+    "            )\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"No segment available to visualize.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "## 9. Scaling Up\n",
+    "\n",
+    "Increase `EPISODE_LIMIT` for broader search, or set it to `None` to process every episode under `DATA_ROOT`. Feature and embedding parquets land in `FEATURES_DIR` and `EMBEDDINGS_DIR` so you can reload them in a later session with `daft.read_parquet(...)` instead of recomputing."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ test = [
 ]
 lint = [
     "ruff>=0.9.0",
+    "nbstripout>=0.7.1",
 ]
 lakehouse = [
     "daft[iceberg,sql]>=0.7.17",

--- a/uv.lock
+++ b/uv.lock
@@ -644,6 +644,7 @@ lakehouse = [
     { name = "sqlalchemy-bigquery" },
 ]
 lint = [
+    { name = "nbstripout" },
     { name = "ruff" },
 ]
 models = [
@@ -688,6 +689,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'lakehouse'" },
     { name = "modal", marker = "extra == 'models'" },
     { name = "modal", marker = "extra == 'transcription'" },
+    { name = "nbstripout", marker = "extra == 'lint'", specifier = ">=0.7.1" },
     { name = "numpy", marker = "extra == 'egodex'" },
     { name = "pillow", marker = "extra == 'egodex'" },
     { name = "pillow", marker = "extra == 'models'" },
@@ -1946,6 +1948,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nbstripout"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nbformat" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6f/b52c4da26babeb521078c08c78c3187a59197098ffc7a70b0fe76851813a/nbstripout-0.9.1.tar.gz", hash = "sha256:313bbb4217c8e38998567e5d790b6bd6c3a17a8c39073b205b84dadfc5d756dc", size = 32356, upload-time = "2026-02-21T16:19:55.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/16/e777eadfa0c0305878c36fae1d5e6db474fbb15dae202b9ec378809dfb4d/nbstripout-0.9.1-py3-none-any.whl", hash = "sha256:ca027ee45742ee77e4f8e9080254f9a707f1161ba11367b82fdf4a29892c759e", size = 19136, upload-time = "2026-02-21T16:19:54.868Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Follow-up to #48. Keeps the example notebooks under `datasets/` committed source-only, so run outputs can't creep back in.

- Adds `nbstripout` to the `lint` extra.
- Wires it into the repo's hand-rolled precommit hook: `make precommit` now runs `nbstripout --verify` on `datasets/**/*.ipynb` and fails if any carries stored outputs or execution counts.
- Adds `make strip-notebooks` to clean them in place.
- Re-serializes `egodex_demo.ipynb` in nbstripout's canonical form (indent 1, deterministic sequential cell ids) so the tool and the committed file agree — future strips are idempotent no-ops.

## Scope

Deliberately scoped to `datasets/`. Four notebooks under `notebooks/` (`window_functions`, `data-ai-summit-2024`, `voice_ai_analytics`, `reddit`) currently ship with rendered outputs, which looks intentional for conference/demo material — so this doesn't touch them or break commits on them. Easy to widen the `DATASET_NOTEBOOKS` glob later if we want repo-wide enforcement.

## Verification

- `make precommit` passes on the clean notebook; `nbstripout --verify` exits non-zero on a notebook with injected outputs (gate works).
- Second `make strip-notebooks` is a no-op (idempotent); notebook stays valid nbformat with 24 unique cell ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)