### PR TITLE
Fix local Transformers prompt example

### DIFF
--- a/examples/hf/transformers_prompt.py
+++ b/examples/hf/transformers_prompt.py
@@ -19,7 +19,7 @@ requests = daft.from_pydict(
             provider="transformers",
             model="HuggingFaceTB/SmolLM2-135M-Instruct",
             max_new_tokens=80,
-            temperature=0.0,
+            do_sample=False,
         ),
     ).show()
 )


### PR DESCRIPTION
## What changed

- Uses `do_sample=False` instead of `temperature=0.0` in the local Transformers prompt example.

## Why

Current Transformers rejects a zero temperature. Explicit greedy decoding preserves deterministic output and lets the `daft==0.7.19` PEP 723 script run successfully.

## Validation

- `uv --no-config run --script examples/hf/transformers_prompt.py`
- `python3 -m py_compile examples/hf/*.py`
- `uvx ruff check examples/hf`
- `uvx ruff format --check examples/hf`